### PR TITLE
fix(import): support imported smtp credentials

### DIFF
--- a/.changelog/51.txt
+++ b/.changelog/51.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mailgun_smtp_credential: Fixed imported SMTP credentials so they no longer require setting a synthetic password in configuration
+```

--- a/docs/resources/smtp_credential.md
+++ b/docs/resources/smtp_credential.md
@@ -32,7 +32,10 @@ output "smtp_full_login" {
 
 - `domain` (String) The domain this SMTP credential belongs to.
 - `login` (String) The login name for SMTP authentication (without the @domain part). The full SMTP username will be 'login@domain'.
-- `password` (String, Sensitive) The password for SMTP authentication. This is write-only and cannot be read back from the API.
+
+### Optional
+
+- `password` (String, Sensitive) The password for SMTP authentication. This is write-only and cannot be read back from the API. Set this when creating a credential or when rotating the password of an imported credential. Leave it unset to keep the existing password of an imported credential.
 
 ### Read-Only
 

--- a/internal/provider/domain_sending_keys/resource.go
+++ b/internal/provider/domain_sending_keys/resource.go
@@ -209,7 +209,7 @@ func (r *domainSendingKeyResource) ImportState(ctx context.Context, req resource
 		Id:          types.StringValue(apiKey.ID),
 		Domain:      types.StringValue(apiKey.DomainName),
 		Description: types.StringValue(apiKey.Description),
-		Secret:      types.StringValue(""), // Secret cannot be retrieved after creation
+		Secret:      types.StringNull(), // Secret cannot be retrieved after creation
 		CreatedAt:   types.StringValue(apiKey.CreatedAt.Format(time.RFC3339)),
 	}
 

--- a/internal/provider/smtp_credentials/resource.go
+++ b/internal/provider/smtp_credentials/resource.go
@@ -191,13 +191,21 @@ func (r *SmtpCredentialResource) Update(ctx context.Context, req resource.Update
 	// Password is write-only and cannot be read back from the API. When it is
 	// unset in configuration for an imported resource, preserve the existing
 	// state and do not attempt a password rotation.
-	if plan.Password.IsNull() || plan.Password.IsUnknown() || password == "" {
+	if plan.Password.IsNull() || plan.Password.IsUnknown() {
 		plan.Password = state.Password
 		plan.Id = state.Id
 		plan.FullLogin = state.FullLogin
 		plan.CreatedAt = state.CreatedAt
 
 		resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+		return
+	}
+
+	if password == "" {
+		resp.Diagnostics.AddError(
+			"Invalid Password",
+			"The password cannot be an empty string. Omit the attribute to preserve the existing imported password, or set a non-empty value to rotate it.",
+		)
 		return
 	}
 

--- a/internal/provider/smtp_credentials/resource.go
+++ b/internal/provider/smtp_credentials/resource.go
@@ -189,9 +189,9 @@ func (r *SmtpCredentialResource) Update(ctx context.Context, req resource.Update
 	password := plan.Password.ValueString()
 
 	// Password is write-only and cannot be read back from the API. When it is
-	// unset in configuration for an imported resource, preserve the existing
-	// state and do not attempt a password rotation.
-	if plan.Password.IsNull() || plan.Password.IsUnknown() {
+	// omitted from configuration for an imported resource, preserve the
+	// existing state and do not attempt a password rotation.
+	if plan.Password.IsNull() {
 		plan.Password = state.Password
 		plan.Id = state.Id
 		plan.FullLogin = state.FullLogin

--- a/internal/provider/smtp_credentials/resource.go
+++ b/internal/provider/smtp_credentials/resource.go
@@ -87,7 +87,7 @@ func (r *SmtpCredentialResource) Create(ctx context.Context, req resource.Create
 		resp.Diagnostics.AddError("Missing Login", "The login is required to create an SMTP credential.")
 		return
 	}
-	if password == "" {
+	if plan.Password.IsNull() || plan.Password.IsUnknown() || password == "" {
 		resp.Diagnostics.AddError("Missing Password", "The password is required to create an SMTP credential.")
 		return
 	}
@@ -187,6 +187,19 @@ func (r *SmtpCredentialResource) Update(ctx context.Context, req resource.Update
 	domain := plan.Domain.ValueString()
 	login := plan.Login.ValueString()
 	password := plan.Password.ValueString()
+
+	// Password is write-only and cannot be read back from the API. When it is
+	// unset in configuration for an imported resource, preserve the existing
+	// state and do not attempt a password rotation.
+	if plan.Password.IsNull() || plan.Password.IsUnknown() || password == "" {
+		plan.Password = state.Password
+		plan.Id = state.Id
+		plan.FullLogin = state.FullLogin
+		plan.CreatedAt = state.CreatedAt
+
+		resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+		return
+	}
 
 	// Create context with timeout
 	updateCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -291,19 +304,12 @@ func (r *SmtpCredentialResource) ImportState(ctx context.Context, req resource.I
 		Login:     types.StringValue(login),
 		FullLogin: types.StringValue(credential.Login),
 		CreatedAt: types.StringValue(time.Time(credential.CreatedAt).Format(time.RFC3339)),
-		// Password cannot be imported - user must set it after import
+		// Password cannot be imported because the API never returns it.
 		Password: types.StringNull(),
 	}
 
 	// Save imported state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-
-	// Warn user that password needs to be set
-	resp.Diagnostics.AddWarning(
-		"Password Required After Import",
-		"The SMTP credential was imported successfully, but the password cannot be retrieved from the API. "+
-			"You must set the 'password' attribute in your configuration to manage this resource.",
-	)
 }
 
 // findCredential searches for a specific credential by domain and login

--- a/internal/provider/smtp_credentials/resource_schema.go
+++ b/internal/provider/smtp_credentials/resource_schema.go
@@ -4,10 +4,12 @@
 package smtp_credentials
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
 // SmtpCredentialResourceSchema returns the schema for the SMTP credential resource
@@ -44,6 +46,9 @@ func SmtpCredentialResourceSchema() rschema.Schema {
 				Optional:  true,
 				Computed:  true,
 				Sensitive: true,
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},

--- a/internal/provider/smtp_credentials/resource_schema.go
+++ b/internal/provider/smtp_credentials/resource_schema.go
@@ -38,9 +38,15 @@ func SmtpCredentialResourceSchema() rschema.Schema {
 				},
 			},
 			"password": rschema.StringAttribute{
-				Description: "The password for SMTP authentication. This is write-only and cannot be read back from the API.",
-				Required:    true,
-				Sensitive:   true,
+				Description: "The password for SMTP authentication. This is write-only and cannot be read back from the API. " +
+					"Set this when creating a credential or when rotating the password of an imported credential. " +
+					"Leave it unset to keep the existing password of an imported credential.",
+				Optional:  true,
+				Computed:  true,
+				Sensitive: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"full_login": rschema.StringAttribute{
 				Description: "The full SMTP login in format 'login@domain'. Use this value for SMTP authentication.",

--- a/internal/provider/smtp_credentials/resource_test.go
+++ b/internal/provider/smtp_credentials/resource_test.go
@@ -127,6 +127,15 @@ func TestAccSmtpCredentialResource(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"password"}, // Password cannot be imported
 			},
+			// Ensure an imported credential remains stable when password is omitted
+			{
+				Config: testAccSmtpCredentialImportedResourceConfig(domainName, loginName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("mailgun_smtp_credential.test", "domain", domainName),
+					resource.TestCheckResourceAttr("mailgun_smtp_credential.test", "login", loginName),
+					resource.TestCheckResourceAttr("mailgun_smtp_credential.test", "full_login", fmt.Sprintf("%s@%s", loginName, domainName)),
+				),
+			},
 			// Update password testing
 			{
 				Config: testAccSmtpCredentialResourceConfig(domainName, loginName, "updated-password-456"),
@@ -178,6 +187,19 @@ resource "mailgun_smtp_credential" "test" {
   password = "%s"
 }
 `, os.Getenv("MAILGUN_API_KEY"), domain, login, password)
+}
+
+func testAccSmtpCredentialImportedResourceConfig(domain, login string) string {
+	return fmt.Sprintf(`
+provider "mailgun" {
+  api_key = "%s"
+}
+
+resource "mailgun_smtp_credential" "test" {
+  domain = "%s"
+  login  = "%s"
+}
+`, os.Getenv("MAILGUN_API_KEY"), domain, login)
 }
 
 func testAccSmtpCredentialsListDataSourceConfig(domain string) string {

--- a/internal/provider/smtp_credentials/resource_test.go
+++ b/internal/provider/smtp_credentials/resource_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"testing"
 
+	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
@@ -21,7 +22,7 @@ func TestSmtpCredentialResourceSchema_HasRequiredFields(t *testing.T) {
 	schema := smtp_credentials.SmtpCredentialResourceSchema()
 
 	// Verify key fields exist
-	requiredFields := []string{"domain", "login", "password"}
+	requiredFields := []string{"domain", "login"}
 	for _, field := range requiredFields {
 		if schema.Attributes[field] == nil {
 			t.Errorf("Schema missing required '%s' attribute", field)
@@ -38,6 +39,19 @@ func TestSmtpCredentialResourceSchema_HasRequiredFields(t *testing.T) {
 	// Verify description exists
 	if schema.Description == "" {
 		t.Error("Schema should have a description")
+	}
+
+	passwordAttr, ok := schema.Attributes["password"].(rschema.StringAttribute)
+	if !ok {
+		t.Fatal("Schema missing string 'password' attribute")
+	}
+
+	if !passwordAttr.Optional {
+		t.Error("Password should be optional to support imported credentials")
+	}
+
+	if !passwordAttr.Computed {
+		t.Error("Password should be computed to preserve state for imported credentials")
 	}
 }
 


### PR DESCRIPTION
## Summary
- make `mailgun_smtp_credential.password` optional/computed so imported credentials do not require a synthetic password in configuration
- preserve imported SMTP credential state when password is unset, and remove the misleading post-import warning
- store imported domain sending key `secret` as `null` instead of an empty string
- regenerate SMTP credential resource docs

## Validation
- `/Users/dimos/.local/share/mise/installs/go/1.24.11/bin/go test ./...`