### PR TITLE
Provider produced inconsistent result after apply when use_automatic_sender_security = true

### DIFF
--- a/.changelog/53.txt
+++ b/.changelog/53.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Provider: Fixed inconsistent result on applying when use_automatic_sender_security = true
+```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # Terraform Provider for Mailgun
 
 This Terraform provider allows you to manage [Mailgun](https://www.mailgun.com/) resources through Terraform. It provides the ability to create, read, update, and delete Mailgun domains, SMTP credentials, and API keys.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Terraform Provider for Mailgun
 
 This Terraform provider allows you to manage [Mailgun](https://www.mailgun.com/) resources through Terraform. It provides the ability to create, read, update, and delete Mailgun domains, SMTP credentials, and API keys.

--- a/internal/provider/domains/resource.go
+++ b/internal/provider/domains/resource.go
@@ -518,6 +518,7 @@ func mapDomainResponseToModel(domainResp mtypes.GetDomainResponse, model DomainM
 	model.WebPrefix = types.StringValue(domainResp.Domain.WebPrefix)
 	model.UseAutomaticSenderSecurity = types.BoolValue(domainResp.Domain.UseAutomaticSenderSecurity)
 
+
 	// Map DNS records from response
 	if len(domainResp.ReceivingDNSRecords) > 0 {
 		receivingRecords := make([]ReceivingDnsRecordsValue, len(domainResp.ReceivingDNSRecords))

--- a/internal/provider/domains/resource.go
+++ b/internal/provider/domains/resource.go
@@ -516,7 +516,7 @@ func mapDomainResponseToModel(domainResp mtypes.GetDomainResponse, model DomainM
 	model.Wildcard = types.BoolValue(domainResp.Domain.Wildcard)
 	model.WebScheme = types.StringValue(domainResp.Domain.WebScheme)
 	model.WebPrefix = types.StringValue(domainResp.Domain.WebPrefix)
-	model.UseAutomaticSenderSecurity = types.BoolValue(domainResp.UseAutomaticSenderSecurity)
+	model.UseAutomaticSenderSecurity = types.BoolValue(domainResp.Domain.UseAutomaticSenderSecurity)
 
 	// Map DNS records from response
 	if len(domainResp.ReceivingDNSRecords) > 0 {

--- a/internal/provider/domains/resource.go
+++ b/internal/provider/domains/resource.go
@@ -518,7 +518,6 @@ func mapDomainResponseToModel(domainResp mtypes.GetDomainResponse, model DomainM
 	model.WebPrefix = types.StringValue(domainResp.Domain.WebPrefix)
 	model.UseAutomaticSenderSecurity = types.BoolValue(domainResp.Domain.UseAutomaticSenderSecurity)
 
-
 	// Map DNS records from response
 	if len(domainResp.ReceivingDNSRecords) > 0 {
 		receivingRecords := make([]ReceivingDnsRecordsValue, len(domainResp.ReceivingDNSRecords))

--- a/internal/provider/domains/resource_test.go
+++ b/internal/provider/domains/resource_test.go
@@ -268,7 +268,6 @@ func TestAccDomainResource_AutomaticSenderSecurity(t *testing.T) {
 	}
 
 	domainName := test_helpers.RandomDomainName()
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { test_helpers.AccPreCheck(t) },
 		ProtoV6ProviderFactories: test_helpers.ProtoV6ProviderFactories,

--- a/internal/provider/domains/resource_test.go
+++ b/internal/provider/domains/resource_test.go
@@ -261,6 +261,63 @@ func TestAccDomainResource_Wildcard(t *testing.T) {
 	})
 }
 
+func TestAccDomainResource_AutomaticSenderSecurity(t *testing.T) {
+	// Skip if MAILGUN_API_KEY is not set
+	if os.Getenv("MAILGUN_API_KEY") == "" {
+		t.Skip("MAILGUN_API_KEY environment variable is not set")
+	}
+
+	domainName := test_helpers.RandomDomainName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test_helpers.AccPreCheck(t) },
+		ProtoV6ProviderFactories: test_helpers.ProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDomainResourceDestroy,
+		Steps: []resource.TestStep{
+			// Create with use_automatic_sender_security = true and verify it is applied
+			{
+				Config: testAccDomainResourceConfigWithAutomaticSenderSecurity(domainName, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("mailgun_domain.test_ass", "name", domainName),
+					resource.TestCheckResourceAttr("mailgun_domain.test_ass", "use_automatic_sender_security", "true"),
+					resource.TestCheckResourceAttrSet("mailgun_domain.test_ass", "id"),
+					resource.TestCheckResourceAttrSet("mailgun_domain.test_ass", "state"),
+					resource.TestCheckResourceAttrSet("mailgun_domain.test_ass", "created_at"),
+				),
+			},
+			// Re-apply the same config and verify there is no diff (idempotency check)
+			{
+				Config:             testAccDomainResourceConfigWithAutomaticSenderSecurity(domainName, true),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			// ImportState testing
+			{
+				ResourceName:            "mailgun_domain.test_ass",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"smtp_password", "dkim_key_size", "force_dkim_authority"},
+			},
+		},
+	})
+}
+
+func testAccDomainResourceConfigWithAutomaticSenderSecurity(domainName string, useAutomaticSenderSecurity bool) string {
+	return fmt.Sprintf(`
+provider "mailgun" {
+  api_key = "%s"
+}
+
+resource "mailgun_domain" "test_ass" {
+  name                          = "%s"
+  spam_action                   = "disabled"
+  wildcard                      = false
+  web_scheme                    = "https"
+  use_automatic_sender_security = %t
+}
+`, os.Getenv("MAILGUN_API_KEY"), domainName, useAutomaticSenderSecurity)
+}
+
 func testAccDomainResourceConfig(domainName, spamAction string, wildcard bool, webScheme string) string {
 	return fmt.Sprintf(`
 provider "mailgun" {


### PR DESCRIPTION
**Issue**
The provider has an issue in its Read logic (within resource.go). It attempts to read the use_automatic_sender_security attribute from the top-level of the JSON response body, whereas the Mailgun API actually returns this value nested inside the domain object.

Because the provider's logic fails to find the value where it expects it, it defaults to false (the Go zero-value for a boolean). This creates a "phantom" diff:

**Impact**
**State**: Your Terraform state thinks you set use_automatic_sender_security = true.
**Read/Refresh:** The provider reads the API, fails to find the field at the top level, and reports back false.
**Conflict:** Terraform sees that the API returned false while your configuration/state says true. It tries to trigger an update to fix it, but because the provider logic is flawed, the cycle never reconciles, eventually crashing with the "Provider produced inconsistent result" error.




**Error logs**
```
> $ tf version
Terraform v1.6.6
on linux_amd64

Initializing provider plugins...
- Reusing previous version of hackthebox/mailgun from the dependency lock file
- Reusing previous version of hashicorp/null from the dependency lock file
- Reusing previous version of hashicorp/random from the dependency lock file
- Reusing previous version of hashicorp/google from the dependency lock file
- Using hackthebox/mailgun v1.0.4 from the shared cache directory
- Using hashicorp/null v3.2.4 from the shared cache directory
- Using hashicorp/random v3.8.1 from the shared cache directory
- Using hashicorp/google v5.45.2 from the shared cache directory

│ Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to mailgun_domain.this["example-app"], provider
│ "provider[\"registry.terraform.io/hackthebox/mailgun\"]" produced an
│ unexpected new value: .use_automatic_sender_security: was cty.True, but now
│ cty.False.
│ 
│ This is a bug in the provider, which should be reported in the provider's
│ own issue tracker.
```

**Fix applied**
Patched internal/provider/domains/resource.go to correctly map the attribute from the nested domainResp.Domain struct, added a new acceptance test in internal/provider/domains/resource_test.go to verify the fix.


Thanks in advance. 