### PR TITLE
fix(domains): stop spurious domain replacement on in-place updates

### DIFF
--- a/.changelog/61.txt
+++ b/.changelog/61.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mailgun_domain: Fixed spurious domain replacement on in-place updates. The `spam_action`, `wildcard`, `force_dkim_authority`, and `dkim_key_size` attributes (Optional+Computed+RequiresReplace) lacked `UseStateForUnknown`, so any update to an existing domain planned them as "known after apply" and forced a full destroy/recreate.
+```

--- a/internal/provider/domains/resource_schema.go
+++ b/internal/provider/domains/resource_schema.go
@@ -42,7 +42,8 @@ func DomainResourceSchema() rschema.Schema {
 					stringvalidator.OneOf("disabled", "tag", "delete"),
 				},
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(), // SDK doesn't support updating spam_action
+					stringplanmodifier.UseStateForUnknown(), // keep prior value when unset so updates don't force replacement
+					stringplanmodifier.RequiresReplace(),    // SDK doesn't support updating spam_action
 				},
 			},
 			"wildcard": rschema.BoolAttribute{
@@ -50,7 +51,8 @@ func DomainResourceSchema() rschema.Schema {
 				Optional:    true,
 				Computed:    true,
 				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.RequiresReplace(), // SDK doesn't support updating wildcard
+					boolplanmodifier.UseStateForUnknown(), // keep prior value when unset so updates don't force replacement
+					boolplanmodifier.RequiresReplace(),    // SDK doesn't support updating wildcard
 				},
 			},
 			"force_dkim_authority": rschema.BoolAttribute{
@@ -58,7 +60,8 @@ func DomainResourceSchema() rschema.Schema {
 				Optional:    true,
 				Computed:    true,
 				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.RequiresReplace(), // SDK doesn't support updating force_dkim_authority
+					boolplanmodifier.UseStateForUnknown(), // keep prior value when unset so updates don't force replacement
+					boolplanmodifier.RequiresReplace(),    // SDK doesn't support updating force_dkim_authority
 				},
 			},
 			"dkim_key_size": rschema.StringAttribute{
@@ -69,7 +72,8 @@ func DomainResourceSchema() rschema.Schema {
 					stringvalidator.OneOf("1024", "2048"),
 				},
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(), // SDK doesn't support updating dkim_key_size
+					stringplanmodifier.UseStateForUnknown(), // keep prior value when unset so updates don't force replacement
+					stringplanmodifier.RequiresReplace(),    // SDK doesn't support updating dkim_key_size
 				},
 			},
 			"ips": rschema.StringAttribute{

--- a/internal/provider/domains/resource_test.go
+++ b/internal/provider/domains/resource_test.go
@@ -227,8 +227,27 @@ func TestAccDomainResource(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"smtp_password", "dkim_key_size", "force_dkim_authority"},
 			},
-			// Delete testing automatically occurs in TestCase
-			// Note: spam_action and wildcard require replacement, so we skip update testing for those
+			{
+				Config: testAccDomainResourceConfigWithAutomaticSenderSecurity(domainName, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("mailgun_domain.test", "name", domainName),
+					resource.TestCheckResourceAttr("mailgun_domain.test", "use_automatic_sender_security", "true"),
+					resource.TestCheckResourceAttrSet("mailgun_domain.test", "id"),
+					resource.TestCheckResourceAttrSet("mailgun_domain.test", "state"),
+					resource.TestCheckResourceAttrSet("mailgun_domain.test", "created_at"),
+				),
+			},
+			{
+				Config:             testAccDomainResourceConfigWithAutomaticSenderSecurity(domainName, true),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				ResourceName:            "mailgun_domain.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"smtp_password", "dkim_key_size", "force_dkim_authority"},
+			},
 		},
 	})
 }
@@ -261,57 +280,17 @@ func TestAccDomainResource_Wildcard(t *testing.T) {
 	})
 }
 
-func TestAccDomainResource_AutomaticSenderSecurity(t *testing.T) {
-	// Skip if MAILGUN_API_KEY is not set
-	if os.Getenv("MAILGUN_API_KEY") == "" {
-		t.Skip("MAILGUN_API_KEY environment variable is not set")
-	}
-
-	domainName := test_helpers.RandomDomainName()
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { test_helpers.AccPreCheck(t) },
-		ProtoV6ProviderFactories: test_helpers.ProtoV6ProviderFactories,
-		CheckDestroy:             testAccCheckDomainResourceDestroy,
-		Steps: []resource.TestStep{
-			// Create with use_automatic_sender_security = true and verify it is applied
-			{
-				Config: testAccDomainResourceConfigWithAutomaticSenderSecurity(domainName, true),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("mailgun_domain.test_ass", "name", domainName),
-					resource.TestCheckResourceAttr("mailgun_domain.test_ass", "use_automatic_sender_security", "true"),
-					resource.TestCheckResourceAttrSet("mailgun_domain.test_ass", "id"),
-					resource.TestCheckResourceAttrSet("mailgun_domain.test_ass", "state"),
-					resource.TestCheckResourceAttrSet("mailgun_domain.test_ass", "created_at"),
-				),
-			},
-			// Re-apply the same config and verify there is no diff (idempotency check)
-			{
-				Config:             testAccDomainResourceConfigWithAutomaticSenderSecurity(domainName, true),
-				PlanOnly:           true,
-				ExpectNonEmptyPlan: false,
-			},
-			// ImportState testing
-			{
-				ResourceName:            "mailgun_domain.test_ass",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"smtp_password", "dkim_key_size", "force_dkim_authority"},
-			},
-		},
-	})
-}
-
 func testAccDomainResourceConfigWithAutomaticSenderSecurity(domainName string, useAutomaticSenderSecurity bool) string {
 	return fmt.Sprintf(`
 provider "mailgun" {
   api_key = "%s"
 }
 
-resource "mailgun_domain" "test_ass" {
+resource "mailgun_domain" "test" {
   name                          = "%s"
   spam_action                   = "disabled"
   wildcard                      = false
-  web_scheme                    = "https"
+  web_scheme                    = "http"
   use_automatic_sender_security = %t
 }
 `, os.Getenv("MAILGUN_API_KEY"), domainName, useAutomaticSenderSecurity)

--- a/internal/provider/domains/resource_test.go
+++ b/internal/provider/domains/resource_test.go
@@ -4,15 +4,13 @@
 package domains_test
 
 import (
+	"context"
 	"fmt"
 	"os"
-	"reflect"
 	"testing"
 	"time"
 
 	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -165,21 +163,22 @@ func TestDomainResourceSchema_HasRequiredFields(t *testing.T) {
 }
 
 // attrUsesStateForUnknown reports whether a schema attribute carries the
-// UseStateForUnknown plan modifier, detected by concrete modifier type so the
-// check does not depend on upstream description wording.
-func attrUsesStateForUnknown(attr rschema.Attribute) bool {
+// UseStateForUnknown plan modifier, detected via its description string.
+// Behavior is also guarded end-to-end by the in-place-update acceptance test;
+// this is the fast, no-API canary that additionally covers spam_action and
+// wildcard (which that test always sets in config, so it never exercises them).
+func attrUsesStateForUnknown(ctx context.Context, attr rschema.Attribute) bool {
+	const desc = "Once set, the value of this attribute in state will not change."
 	switch a := attr.(type) {
 	case rschema.StringAttribute:
-		want := reflect.TypeOf(stringplanmodifier.UseStateForUnknown())
 		for _, m := range a.PlanModifiers {
-			if reflect.TypeOf(m) == want {
+			if m.Description(ctx) == desc {
 				return true
 			}
 		}
 	case rschema.BoolAttribute:
-		want := reflect.TypeOf(boolplanmodifier.UseStateForUnknown())
 		for _, m := range a.PlanModifiers {
-			if reflect.TypeOf(m) == want {
+			if m.Description(ctx) == desc {
 				return true
 			}
 		}
@@ -192,6 +191,7 @@ func attrUsesStateForUnknown(attr rschema.Attribute) bool {
 // apply" on every in-place update, and RequiresReplace turns that null->unknown
 // transition into a spurious full replacement of the domain.
 func TestDomainResourceSchema_RequiresReplaceFieldsUseStateForUnknown(t *testing.T) {
+	ctx := t.Context()
 	s := domains.DomainResourceSchema()
 
 	for _, name := range []string{"spam_action", "wildcard", "force_dkim_authority", "dkim_key_size"} {
@@ -200,7 +200,7 @@ func TestDomainResourceSchema_RequiresReplaceFieldsUseStateForUnknown(t *testing
 			t.Errorf("schema is missing attribute %q", name)
 			continue
 		}
-		if !attrUsesStateForUnknown(attr) {
+		if !attrUsesStateForUnknown(ctx, attr) {
 			t.Errorf("%s must use UseStateForUnknown to avoid forcing replacement on unrelated in-place updates", name)
 		}
 	}

--- a/internal/provider/domains/resource_test.go
+++ b/internal/provider/domains/resource_test.go
@@ -4,11 +4,13 @@
 package domains_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
 	"time"
 
+	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -160,6 +162,42 @@ func TestDomainResourceSchema_HasRequiredFields(t *testing.T) {
 	}
 }
 
+// attrUsesStateForUnknown reports whether a schema attribute carries the
+// UseStateForUnknown plan modifier, detected via its stable description string.
+func attrUsesStateForUnknown(ctx context.Context, attr rschema.Attribute) bool {
+	const desc = "Once set, the value of this attribute in state will not change."
+	switch a := attr.(type) {
+	case rschema.StringAttribute:
+		for _, m := range a.PlanModifiers {
+			if m.Description(ctx) == desc {
+				return true
+			}
+		}
+	case rschema.BoolAttribute:
+		for _, m := range a.PlanModifiers {
+			if m.Description(ctx) == desc {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// Optional+Computed attributes that force replacement must also use
+// UseStateForUnknown. Without it, the framework plans them as "known after
+// apply" on every in-place update, and RequiresReplace turns that null->unknown
+// transition into a spurious full replacement of the domain.
+func TestDomainResourceSchema_RequiresReplaceFieldsUseStateForUnknown(t *testing.T) {
+	ctx := t.Context()
+	s := domains.DomainResourceSchema()
+
+	for _, name := range []string{"spam_action", "wildcard", "force_dkim_authority", "dkim_key_size"} {
+		if !attrUsesStateForUnknown(ctx, s.Attributes[name]) {
+			t.Errorf("%s must use UseStateForUnknown to avoid forcing replacement on unrelated in-place updates", name)
+		}
+	}
+}
+
 // Mock test for SDK to Model conversion logic
 func TestSDKToTerraformConversion(t *testing.T) {
 	// Create a mock SDK response similar to what Mailgun API returns
@@ -227,24 +265,8 @@ func TestAccDomainResource(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"smtp_password", "dkim_key_size", "force_dkim_authority"},
 			},
-		},
-	})
-}
-
-func TestAccDomainResource_AutomaticSenderSecurity(t *testing.T) {
-	if os.Getenv("MAILGUN_MULTI_DOMAIN") == "" {
-		t.Skip("Skipping automatic sender security test - most Mailgun test accounts have a 1 domain limit. Set MAILGUN_MULTI_DOMAIN=1 to run this test.")
-	}
-	if os.Getenv("MAILGUN_API_KEY") == "" {
-		t.Skip("MAILGUN_API_KEY environment variable is not set")
-	}
-
-	domainName := test_helpers.RandomDomainName()
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { test_helpers.AccPreCheck(t) },
-		ProtoV6ProviderFactories: test_helpers.ProtoV6ProviderFactories,
-		CheckDestroy:             testAccCheckDomainResourceDestroy,
-		Steps: []resource.TestStep{
+			// In-place update must not force a replacement (regression guard for the
+			// Optional+Computed+RequiresReplace plan-modifier bug).
 			{
 				Config: testAccDomainResourceConfigWithAutomaticSenderSecurity(domainName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(

--- a/internal/provider/domains/resource_test.go
+++ b/internal/provider/domains/resource_test.go
@@ -4,13 +4,15 @@
 package domains_test
 
 import (
-	"context"
 	"fmt"
 	"os"
+	"reflect"
 	"testing"
 	"time"
 
 	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -163,19 +165,21 @@ func TestDomainResourceSchema_HasRequiredFields(t *testing.T) {
 }
 
 // attrUsesStateForUnknown reports whether a schema attribute carries the
-// UseStateForUnknown plan modifier, detected via its stable description string.
-func attrUsesStateForUnknown(ctx context.Context, attr rschema.Attribute) bool {
-	const desc = "Once set, the value of this attribute in state will not change."
+// UseStateForUnknown plan modifier, detected by concrete modifier type so the
+// check does not depend on upstream description wording.
+func attrUsesStateForUnknown(attr rschema.Attribute) bool {
 	switch a := attr.(type) {
 	case rschema.StringAttribute:
+		want := reflect.TypeOf(stringplanmodifier.UseStateForUnknown())
 		for _, m := range a.PlanModifiers {
-			if m.Description(ctx) == desc {
+			if reflect.TypeOf(m) == want {
 				return true
 			}
 		}
 	case rschema.BoolAttribute:
+		want := reflect.TypeOf(boolplanmodifier.UseStateForUnknown())
 		for _, m := range a.PlanModifiers {
-			if m.Description(ctx) == desc {
+			if reflect.TypeOf(m) == want {
 				return true
 			}
 		}
@@ -188,7 +192,6 @@ func attrUsesStateForUnknown(ctx context.Context, attr rschema.Attribute) bool {
 // apply" on every in-place update, and RequiresReplace turns that null->unknown
 // transition into a spurious full replacement of the domain.
 func TestDomainResourceSchema_RequiresReplaceFieldsUseStateForUnknown(t *testing.T) {
-	ctx := t.Context()
 	s := domains.DomainResourceSchema()
 
 	for _, name := range []string{"spam_action", "wildcard", "force_dkim_authority", "dkim_key_size"} {
@@ -197,7 +200,7 @@ func TestDomainResourceSchema_RequiresReplaceFieldsUseStateForUnknown(t *testing
 			t.Errorf("schema is missing attribute %q", name)
 			continue
 		}
-		if !attrUsesStateForUnknown(ctx, attr) {
+		if !attrUsesStateForUnknown(attr) {
 			t.Errorf("%s must use UseStateForUnknown to avoid forcing replacement on unrelated in-place updates", name)
 		}
 	}

--- a/internal/provider/domains/resource_test.go
+++ b/internal/provider/domains/resource_test.go
@@ -192,7 +192,12 @@ func TestDomainResourceSchema_RequiresReplaceFieldsUseStateForUnknown(t *testing
 	s := domains.DomainResourceSchema()
 
 	for _, name := range []string{"spam_action", "wildcard", "force_dkim_authority", "dkim_key_size"} {
-		if !attrUsesStateForUnknown(ctx, s.Attributes[name]) {
+		attr, ok := s.Attributes[name]
+		if !ok {
+			t.Errorf("schema is missing attribute %q", name)
+			continue
+		}
+		if !attrUsesStateForUnknown(ctx, attr) {
 			t.Errorf("%s must use UseStateForUnknown to avoid forcing replacement on unrelated in-place updates", name)
 		}
 	}

--- a/internal/provider/domains/resource_test.go
+++ b/internal/provider/domains/resource_test.go
@@ -227,6 +227,24 @@ func TestAccDomainResource(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"smtp_password", "dkim_key_size", "force_dkim_authority"},
 			},
+		},
+	})
+}
+
+func TestAccDomainResource_AutomaticSenderSecurity(t *testing.T) {
+	if os.Getenv("MAILGUN_MULTI_DOMAIN") == "" {
+		t.Skip("Skipping automatic sender security test - most Mailgun test accounts have a 1 domain limit. Set MAILGUN_MULTI_DOMAIN=1 to run this test.")
+	}
+	if os.Getenv("MAILGUN_API_KEY") == "" {
+		t.Skip("MAILGUN_API_KEY environment variable is not set")
+	}
+
+	domainName := test_helpers.RandomDomainName()
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test_helpers.AccPreCheck(t) },
+		ProtoV6ProviderFactories: test_helpers.ProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDomainResourceDestroy,
+		Steps: []resource.TestStep{
 			{
 				Config: testAccDomainResourceConfigWithAutomaticSenderSecurity(domainName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(


### PR DESCRIPTION
## Summary

Acceptance tests were failing in CI with a 403 \"Domains limit of 1 exceeded\". Root-causing this surfaced a real provider bug, not just a test arrangement issue.

**Root cause:** `spam_action`, `wildcard`, `force_dkim_authority`, and `dkim_key_size` are `Optional + Computed + RequiresReplace()` but had no `UseStateForUnknown()`. On any in-place update, the framework plans these as \"known after apply\" (unknown), and `RequiresReplace()` treats the prior `null` → `unknown` transition as a change, forcing a full destroy/recreate. The recreate's destroy-then-create then hits Mailgun's 1-domain limit (the slot is not freed immediately), surfacing as a 403. This affected **every** update to an existing domain.

Verified with a live `terraform plan` against the real API:
- Before: `Plan: 1 to add, 0 to change, 1 to destroy` (`# forces replacement` on `dkim_key_size` / `force_dkim_authority`)
- After: `# mailgun_domain.test will be updated in-place` / `Plan: 0 to add, 1 to change, 0 to destroy`

## Changes

- `resource/mailgun_domain`: add `UseStateForUnknown()` to the four `Optional+Computed+RequiresReplace` attributes so unset values carry from prior state and only an explicit config change forces replacement.
- Fold the automatic sender security coverage into `TestAccDomainResource` as an **in-place update** (create → import → enable ASS → idempotency → import). No second domain is created, so it runs on default 1-domain CI accounts and guards the regression.
- Add a unit test asserting the four attributes carry `UseStateForUnknown`.
- Changelog entry (`bug`).

## Test plan

- [x] `TestAccDomainResource` passes end-to-end against a 1-domain account (full `domains` package acceptance suite green locally).
- [x] Unit test `TestDomainResourceSchema_RequiresReplaceFieldsUseStateForUnknown` (RED before fix, GREEN after).

## Out of scope (follow-ups worth filing)

- `Read` returns an error on HTTP 404 instead of removing the resource from state (observed during repro when a domain was deleted out-of-band).