### PR TITLE
fix(domains): retry transient 404s on domain reads (eventual consistency)

### DIFF
--- a/.changelog/62.txt
+++ b/.changelog/62.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mailgun_domain: Retry transient 404s when reading a domain to tolerate Mailgun's eventual consistency (a GET can 404 immediately after a successful create/update), instead of failing the read.
+```

--- a/internal/provider/domains/resource.go
+++ b/internal/provider/domains/resource.go
@@ -172,6 +172,47 @@ func (r *DomainResource) Create(ctx context.Context, req resource.CreateRequest,
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
+const (
+	// domainReadMaxAttempts and domainReadRetryDelay bound how long a GET waits
+	// out Mailgun's eventual consistency: a GET can return 404 right after a
+	// successful write, before the domain is globally visible.
+	domainReadMaxAttempts = 5
+	domainReadRetryDelay  = 2 * time.Second
+)
+
+// getDomainWithRetry fetches a domain, retrying transient 404s up to attempts
+// times with a fixed delay between tries. Non-404 errors return immediately.
+func getDomainWithRetry(ctx context.Context, client *mailgun.Client, name string, attempts int, delay time.Duration) (mtypes.GetDomainResponse, error) {
+	var resp mtypes.GetDomainResponse
+	var err error
+	for attempt := range attempts {
+		if attempt > 0 {
+			if werr := sleepWithContext(ctx, delay); werr != nil {
+				return resp, werr
+			}
+		}
+		resp, err = client.GetDomain(ctx, name, nil)
+		if err == nil {
+			return resp, nil
+		}
+		if mailgun.GetStatusFromErr(err) != http.StatusNotFound {
+			return resp, err
+		}
+	}
+	return resp, err
+}
+
+// sleepWithContext waits for d or until ctx is cancelled, returning ctx.Err()
+// if it is cancelled first.
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(d):
+		return nil
+	}
+}
+
 // Read refreshes the Terraform state with the latest data.
 func (r *DomainResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state DomainModel
@@ -207,7 +248,7 @@ func (r *DomainResource) Read(ctx context.Context, req resource.ReadRequest, res
 	defer cancel()
 
 	// Get the domain via Mailgun API
-	domainResp, err := r.client.GetDomain(readCtx, domainName, nil)
+	domainResp, err := getDomainWithRetry(readCtx, r.client, domainName, domainReadMaxAttempts, domainReadRetryDelay)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading Domain",
@@ -295,7 +336,7 @@ func (r *DomainResource) Update(ctx context.Context, req resource.UpdateRequest,
 	}
 
 	// Fetch the latest domain state
-	domainResp, err := r.client.GetDomain(updateCtx, domainName, nil)
+	domainResp, err := getDomainWithRetry(updateCtx, r.client, domainName, domainReadMaxAttempts, domainReadRetryDelay)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading Domain After Update",
@@ -387,7 +428,7 @@ func (r *DomainResource) ImportState(ctx context.Context, req resource.ImportSta
 	defer cancel()
 
 	// Get the domain via Mailgun API
-	domainResp, err := r.client.GetDomain(importCtx, domainName, nil)
+	domainResp, err := getDomainWithRetry(importCtx, r.client, domainName, domainReadMaxAttempts, domainReadRetryDelay)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Importing Domain",

--- a/internal/provider/domains/resource_retry_internal_test.go
+++ b/internal/provider/domains/resource_retry_internal_test.go
@@ -1,0 +1,125 @@
+// Copyright (c) Hack The Box
+// SPDX-License-Identifier: MPL-2.0
+
+package domains
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/mailgun/mailgun-go/v5"
+)
+
+func testClient(t *testing.T, handler http.HandlerFunc) *mailgun.Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	mg := mailgun.NewMailgun("test-key")
+	if err := mg.SetAPIBase(srv.URL); err != nil {
+		t.Fatalf("SetAPIBase: %v", err)
+	}
+	return mg
+}
+
+func okDomainResponse(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"domain":{"name":"test.example.com","state":"active"}}`))
+}
+
+// Mailgun is eventually consistent: a GET can 404 right after a successful
+// write. getDomainWithRetry must absorb that transient 404.
+func TestGetDomainWithRetry_RetriesTransient404(t *testing.T) {
+	var calls int
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		if calls < 3 {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"message":"Domain not found"}`))
+			return
+		}
+		okDomainResponse(w)
+	})
+
+	resp, err := getDomainWithRetry(t.Context(), client, "test.example.com", 5, time.Millisecond)
+	if err != nil {
+		t.Fatalf("expected success after transient 404s, got error: %v", err)
+	}
+	if resp.Domain.Name != "test.example.com" {
+		t.Errorf("expected domain name to be set, got %q", resp.Domain.Name)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 attempts, got %d", calls)
+	}
+}
+
+func TestGetDomainWithRetry_Persistent404Errors(t *testing.T) {
+	var calls int
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Domain not found"}`))
+	})
+
+	_, err := getDomainWithRetry(t.Context(), client, "test.example.com", 3, time.Millisecond)
+	if err == nil {
+		t.Fatal("expected an error for persistent 404")
+	}
+	if got := mailgun.GetStatusFromErr(err); got != http.StatusNotFound {
+		t.Errorf("expected 404 status in error, got %d", got)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 attempts, got %d", calls)
+	}
+}
+
+func TestGetDomainWithRetry_SuccessFirstTry(t *testing.T) {
+	var calls int
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		okDomainResponse(w)
+	})
+
+	if _, err := getDomainWithRetry(t.Context(), client, "test.example.com", 5, time.Millisecond); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 attempt, got %d", calls)
+	}
+}
+
+func TestSleepWithContext_ReturnsAfterDelay(t *testing.T) {
+	if err := sleepWithContext(t.Context(), time.Millisecond); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSleepWithContext_ReturnsOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if err := sleepWithContext(ctx, time.Hour); err == nil {
+		t.Fatal("expected context cancellation error")
+	}
+}
+
+// Non-404 errors are not eventual-consistency artifacts and must not be retried.
+func TestGetDomainWithRetry_Non404NotRetried(t *testing.T) {
+	var calls int
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"boom"}`))
+	})
+
+	_, err := getDomainWithRetry(t.Context(), client, "test.example.com", 5, time.Millisecond)
+	if err == nil {
+		t.Fatal("expected an error for 500")
+	}
+	if calls != 1 {
+		t.Errorf("expected no retry on 500, got %d attempts", calls)
+	}
+}


### PR DESCRIPTION
## Summary

Mailgun is **eventually consistent**: a `GET /v4/domains/{name}` can return `404 "Domain not found"` immediately after a successful create/update, before the domain is globally visible. The acceptance-test framework runs a post-apply refresh (the resource's `Read`) right after create, and our `Read` returned a hard `Error Reading Domain` on any non-2xx, so this surfaced as flaky CI failures (e.g. the 1.13 job failing while 1.14 passed on the same commit).

This designs *for* the eventual consistency rather than around it (re-running flaky jobs).

## Changes

- Add `getDomainWithRetry`: retries transient `404`s up to a bounded number of attempts with a fixed backoff; non-404 errors return immediately (no masking of real failures).
- Use it in `Read`, the post-update read-back, and `ImportState`.
- `sleepWithContext` helper for context-aware backoff.
- Unit tests (httptest-backed, no real API): transient-404-then-200, persistent-404, success-first-try, non-404-not-retried, and both sleep paths.

## Test plan

- [x] `go test ./internal/provider/domains/` (unit) green.
- [x] Full `domains` acceptance suite green against a real 1-domain account.

## Notes / follow-ups

- Scoped to the domain resource (where the flake was observed). The same pattern likely belongs in other resources' reads; can generalise into a shared helper when a second resource needs it.
- Separate, related improvement (not in this PR): on a *persistent* 404, `Read` should `RemoveResource` (treat as out-of-band deletion / drift) instead of erroring.