### PR TITLE
ci(dependabot): group dependency updates to reduce PR sprawl

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,27 @@ updates:
     schedule:
       # Check for updates to Go modules every weekday
       interval: "daily"
+    groups:
+      # The terraform-plugin-* packages are interdependent and share a minimum
+      # Go version, so they must be bumped together (a lone bump fails to build).
+      terraform-plugin:
+        patterns:
+          - "github.com/hashicorp/terraform-plugin-*"
+      # Everything else in the main module (runtime SDK + indirect deps).
+      go-modules:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "github.com/hashicorp/terraform-plugin-*"
   - package-ecosystem: "gomod"
     directory: "/tools"
     schedule:
       interval: "daily"
+    # /tools deps all touch the same go.sum; grouping avoids a rebase cascade.
+    groups:
+      tools:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -19,3 +36,7 @@ updates:
     # TODO: Dependabot only updates hashicorp GHAs in the template repository, the following lines can be removed for consumers of this template
     allow:
       - dependency-name: "hashicorp/*"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds `groups` to `.github/dependabot.yml` so future dependency updates arrive as a few grouped PRs instead of a wave of individual ones (this cleanup cycle produced 11 at once).

## Groups
| Ecosystem / dir | Group | Contents |
|-----------------|-------|----------|
| gomod `/` | `terraform-plugin` | `github.com/hashicorp/terraform-plugin-*` — interdependent, share a Go-version floor, must bump together (a lone bump fails to build, as seen with #46/#47/#48) |
| gomod `/` | `go-modules` | everything else (runtime SDK + indirect deps) |
| gomod `/tools` | `tools` | all dev tooling — they all touch `tools/go.sum`, so grouping avoids the rebase cascade |
| github-actions `/` | `github-actions` | all action bumps |

## Effect
A wave like this one collapses from ~11 PRs to ~4. Majors are still grouped here for simplicity; if you'd rather isolate major bumps for individual review, we can add `update-types` later.

ci-only config change → `changelog-not-required`.