### PR TITLE
test(ip_allowlist): fix flaky acceptance tests on shared account

### DIFF
--- a/internal/provider/ip_allowlist/resource_test.go
+++ b/internal/provider/ip_allowlist/resource_test.go
@@ -4,12 +4,15 @@
 package ip_allowlist_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mailgun/mailgun-go/v5"
 
 	"github.com/hackthebox/terraform-provider-mailgun/internal/provider/ip_allowlist"
 	"github.com/hackthebox/terraform-provider-mailgun/internal/provider/test_helpers"
@@ -94,10 +97,10 @@ func TestAccIPAllowlistResource(t *testing.T) {
 	// Setup: Add test runner's IP to allowlist (removed automatically via t.Cleanup)
 	test_helpers.SetupIPAllowlistForTests(t)
 
-	// Use a test IP address that won't affect real access
-	// Using documentation range (RFC 5737)
-	testIP := fmt.Sprintf("192.0.2.%d", test_helpers.RandomInt()%256)
+	testIP := test_helpers.RandomDocIP()
 	description := fmt.Sprintf("test-allowlist-%s", test_helpers.RandomString(8))
+
+	ensureIPAllowlistAbsent(t, testIP)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { test_helpers.AccPreCheck(t) },
@@ -140,9 +143,10 @@ func TestAccIPAllowlistResource_CIDR(t *testing.T) {
 	// Setup: Add test runner's IP to allowlist (removed automatically via t.Cleanup)
 	test_helpers.SetupIPAllowlistForTests(t)
 
-	// Use documentation range CIDR (RFC 5737)
-	testCIDR := "198.51.100.0/24"
+	testCIDR := test_helpers.RandomDocCIDR()
 	description := fmt.Sprintf("test-cidr-%s", test_helpers.RandomString(8))
+
+	ensureIPAllowlistAbsent(t, testCIDR)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { test_helpers.AccPreCheck(t) },
@@ -204,6 +208,26 @@ provider "mailgun" {
 data "mailgun_ip_allowlist" "test" {
 }
 `, os.Getenv("MAILGUN_API_KEY"))
+}
+
+// ensureIPAllowlistAbsent deletes any existing allowlist entry at address so a
+// leftover orphan from a crashed run cannot make the test's create return 409.
+// Best-effort: failures are logged, not fatal.
+func ensureIPAllowlistAbsent(t *testing.T, address string) {
+	t.Helper()
+
+	mg := mailgun.NewMailgun(os.Getenv("MAILGUN_API_KEY"))
+	client := ip_allowlist.NewIPAllowlistClient(mg)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if _, err := client.GetIPAllowlistEntry(ctx, address); err != nil {
+		return
+	}
+	if err := client.DeleteIPAllowlistEntry(ctx, address); err != nil {
+		t.Logf("warning: failed to pre-delete leftover allowlist entry %s: %v", address, err)
+	}
 }
 
 func testAccCheckIPAllowlistDestroy(s *terraform.State) error {

--- a/internal/provider/test_helpers/random.go
+++ b/internal/provider/test_helpers/random.go
@@ -32,3 +32,20 @@ func RandomString(length int) string {
 func RandomName(prefix string) string {
 	return fmt.Sprintf("%s-%d", prefix, RandomInt())
 }
+
+var docRangePrefixes = []string{"192.0.2", "198.51.100", "203.0.113"}
+
+// RandomDocIP returns a random IPv4 address in an RFC 5737 documentation range,
+// giving 768 distinct values to avoid collisions on the shared test account.
+func RandomDocIP() string {
+	prefix := docRangePrefixes[rand.Intn(len(docRangePrefixes))]
+	return fmt.Sprintf("%s.%d", prefix, rand.Intn(256))
+}
+
+// RandomDocCIDR returns a random aligned /30 CIDR in an RFC 5737 documentation
+// range, giving 192 distinct values to avoid collisions on the shared test account.
+func RandomDocCIDR() string {
+	prefix := docRangePrefixes[rand.Intn(len(docRangePrefixes))]
+	base := rand.Intn(64) * 4
+	return fmt.Sprintf("%s.%d/30", prefix, base)
+}

--- a/internal/provider/test_helpers/random_test.go
+++ b/internal/provider/test_helpers/random_test.go
@@ -1,0 +1,90 @@
+// Copyright Hack The Box 2025, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package test_helpers
+
+import (
+	"net"
+	"testing"
+)
+
+// RFC 5737 documentation ranges (never routed, safe for tests).
+var docRangesForTest = []string{"192.0.2.0/24", "198.51.100.0/24", "203.0.113.0/24"}
+
+func parseDocNets(t *testing.T) []*net.IPNet {
+	t.Helper()
+	nets := make([]*net.IPNet, 0, len(docRangesForTest))
+	for _, cidr := range docRangesForTest {
+		_, n, err := net.ParseCIDR(cidr)
+		if err != nil {
+			t.Fatalf("bad doc range %q: %v", cidr, err)
+		}
+		nets = append(nets, n)
+	}
+	return nets
+}
+
+func TestRandomDocIP_WithinDocumentationRange(t *testing.T) {
+	nets := parseDocNets(t)
+	for range 200 {
+		got := RandomDocIP()
+		ip := net.ParseIP(got)
+		if ip == nil {
+			t.Fatalf("RandomDocIP() = %q, not a valid IP", got)
+		}
+		inRange := false
+		for _, n := range nets {
+			if n.Contains(ip) {
+				inRange = true
+				break
+			}
+		}
+		if !inRange {
+			t.Errorf("RandomDocIP() = %q, not in any RFC 5737 documentation range", got)
+		}
+	}
+}
+
+func TestRandomDocIP_ProducesVariety(t *testing.T) {
+	seen := make(map[string]struct{})
+	for range 50 {
+		seen[RandomDocIP()] = struct{}{}
+	}
+	if len(seen) < 2 {
+		t.Errorf("RandomDocIP() produced %d distinct values over 50 calls, expected variety", len(seen))
+	}
+}
+
+func TestRandomDocCIDR_WithinDocumentationRange(t *testing.T) {
+	nets := parseDocNets(t)
+	for range 200 {
+		got := RandomDocCIDR()
+		ip, network, err := net.ParseCIDR(got)
+		if err != nil {
+			t.Fatalf("RandomDocCIDR() = %q, not a valid CIDR: %v", got, err)
+		}
+		if network.String() != got {
+			t.Errorf("RandomDocCIDR() = %q is not a canonical (aligned) network address; got %q", got, network.String())
+		}
+		inRange := false
+		for _, n := range nets {
+			if n.Contains(ip) {
+				inRange = true
+				break
+			}
+		}
+		if !inRange {
+			t.Errorf("RandomDocCIDR() = %q, not in any RFC 5737 documentation range", got)
+		}
+	}
+}
+
+func TestRandomDocCIDR_ProducesVariety(t *testing.T) {
+	seen := make(map[string]struct{})
+	for range 50 {
+		seen[RandomDocCIDR()] = struct{}{}
+	}
+	if len(seen) < 2 {
+		t.Errorf("RandomDocCIDR() produced %d distinct values over 50 calls, expected variety", len(seen))
+	}
+}


### PR DESCRIPTION
Fixes #64.

## Problem
`TestAccIPAllowlistResource` drew from only 256 candidate IPs (`192.0.2.{RandomInt()%256}`) and `TestAccIPAllowlistResource_CIDR` used a **hardcoded** `198.51.100.0/24`. Combined with leftover orphans (a run exiting before `TestMain` cleanup) and Mailgun's eventual consistency on deletes, the next create intermittently hit `409 IP address already exists`. Symptom: same commit, one matrix job passes and another 409s.

## Fix
- **Wider entropy:** new `RandomDocIP()` (768 values) and `RandomDocCIDR()` (192 aligned /30s) helpers spanning all three RFC 5737 documentation ranges (192.0.2 / 198.51.100 / 203.0.113). TDD'd with unit tests (within-range + variety).
- **Delete-if-exists before create:** `ensureIPAllowlistAbsent` removes any leftover orphan at the chosen address before the test applies its config, so a stale entry can't 409. Best-effort (failures logged, not fatal).

## Verification
- `go test ./internal/provider/test_helpers/ ./internal/provider/ip_allowlist/` — pass
- `go vet` — clean
- golangci-lint v2.12.2 — 0 issues
- CRAP gate — `RandomDocIP`/`RandomDocCIDR` at CRAP 1.0, 100% coverage

Test-only change → `changelog-not-required`.