### PR TITLE
fix(provider): retry rate-limited requests and run the acceptance suite in CI

### DIFF
--- a/.changelog/84.txt
+++ b/.changelog/84.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+provider: Retry requests that Mailgun rejects with HTTP 429, honouring `Retry-After` (capped at 30s) with exponential backoff. Previously a rate-limited response surfaced as a hard apply failure.
+```

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,7 @@ jobs:
       - env:
           TF_ACC: "1"
           MAILGUN_API_KEY: ${{ secrets.MAILGUN_API_KEY }}
+          MAILGUN_TEST_DOMAIN: ${{ vars.MAILGUN_TEST_DOMAIN }}
         # -p 1 runs packages sequentially to avoid IP allowlist race conditions
         run: go test -v -cover -p 1 ./...
         timeout-minutes: 10

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
@@ -114,6 +115,7 @@ func (p *mailgunProvider) Configure(ctx context.Context, req provider.ConfigureR
 
 	// Create Mailgun client (v5 API)
 	mg := mailgun.NewMailgun(config.ApiKey.ValueString())
+	mg.SetHTTPClient(&http.Client{Transport: newRateLimitRetryTransport()})
 
 	// Set region if provided
 	if !config.Region.IsNull() {

--- a/internal/provider/retry_transport.go
+++ b/internal/provider/retry_transport.go
@@ -71,10 +71,7 @@ func retryAfterDelay(header string, fallback time.Duration) time.Duration {
 	if err != nil || seconds <= 0 {
 		return fallback
 	}
-	if delay := time.Duration(seconds) * time.Second; delay < maxRetryAfter {
-		return delay
-	}
-	return maxRetryAfter
+	return min(time.Duration(seconds)*time.Second, maxRetryAfter)
 }
 
 func rewindBody(req *http.Request) (*http.Request, bool) {

--- a/internal/provider/retry_transport.go
+++ b/internal/provider/retry_transport.go
@@ -1,0 +1,108 @@
+// Copyright Hack The Box 2025, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+const (
+	rateLimitRetryAttempts = 3
+	baseRetryBackoff       = 2 * time.Second
+	maxRetryAfter          = 30 * time.Second
+)
+
+// rateLimitRetryTransport retries 429s. Mailgun's routes endpoints have a low
+// ceiling that a moderate configuration reaches on its own, and unretried it
+// reaches practitioners as a hard apply failure.
+type rateLimitRetryTransport struct {
+	next     http.RoundTripper
+	attempts int
+	wait     func(context.Context, time.Duration) error
+}
+
+func newRateLimitRetryTransport() rateLimitRetryTransport {
+	return rateLimitRetryTransport{
+		next:     http.DefaultTransport,
+		attempts: rateLimitRetryAttempts,
+		wait:     sleepWithContext,
+	}
+}
+
+func (t rateLimitRetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	for attempt := 0; ; attempt++ {
+		resp, err := t.next.RoundTrip(req)
+		if err != nil {
+			return nil, err
+		}
+		if !t.retryable(resp, attempt) {
+			return resp, nil
+		}
+
+		replay, replayable := rewindBody(req)
+		if !replayable {
+			return resp, nil
+		}
+
+		if err := t.pause(req.Context(), resp, attempt); err != nil {
+			return nil, err
+		}
+		req = replay
+	}
+}
+
+func (t rateLimitRetryTransport) retryable(resp *http.Response, attempt int) bool {
+	return resp.StatusCode == http.StatusTooManyRequests && attempt < t.attempts
+}
+
+func (t rateLimitRetryTransport) pause(ctx context.Context, resp *http.Response, attempt int) error {
+	delay := retryAfterDelay(resp.Header.Get("Retry-After"), baseRetryBackoff<<attempt)
+	resp.Body.Close()
+	return t.wait(ctx, delay)
+}
+
+// retryAfterDelay reads Retry-After, which Mailgun sends as whole seconds.
+func retryAfterDelay(header string, fallback time.Duration) time.Duration {
+	seconds, err := strconv.Atoi(header)
+	if err != nil || seconds <= 0 {
+		return fallback
+	}
+	if delay := time.Duration(seconds) * time.Second; delay < maxRetryAfter {
+		return delay
+	}
+	return maxRetryAfter
+}
+
+func rewindBody(req *http.Request) (*http.Request, bool) {
+	if req.Body == nil {
+		return req, true
+	}
+	if req.GetBody == nil {
+		return nil, false
+	}
+
+	body, err := req.GetBody()
+	if err != nil {
+		return nil, false
+	}
+
+	replay := req.Clone(req.Context())
+	replay.Body = body
+	return replay, true
+}
+
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/provider/retry_transport.go
+++ b/internal/provider/retry_transport.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"strconv"
 	"time"
@@ -14,6 +15,7 @@ const (
 	rateLimitRetryAttempts = 3
 	baseRetryBackoff       = 2 * time.Second
 	maxRetryAfter          = 30 * time.Second
+	drainBodyLimit         = 4096
 )
 
 // rateLimitRetryTransport retries 429s. Mailgun's routes endpoints have a low
@@ -61,7 +63,12 @@ func (t rateLimitRetryTransport) retryable(resp *http.Response, attempt int) boo
 
 func (t rateLimitRetryTransport) pause(ctx context.Context, resp *http.Response, attempt int) error {
 	delay := retryAfterDelay(resp.Header.Get("Retry-After"), baseRetryBackoff<<attempt)
+
+	// net/http pools a keep-alive connection only once its body reaches EOF, so
+	// an undrained close costs the retry a fresh handshake. Bounded: untrusted body.
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, drainBodyLimit))
 	resp.Body.Close()
+
 	return t.wait(ctx, delay)
 }
 

--- a/internal/provider/retry_transport_test.go
+++ b/internal/provider/retry_transport_test.go
@@ -1,0 +1,257 @@
+// Copyright Hack The Box 2025, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+type fakeRoundTripper struct {
+	responses []*http.Response
+	err       error
+	calls     int
+	bodies    []string
+}
+
+func (f *fakeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	f.calls++
+	if req.Body != nil {
+		body, _ := io.ReadAll(req.Body)
+		f.bodies = append(f.bodies, string(body))
+	}
+	if f.err != nil {
+		return nil, f.err
+	}
+	resp := f.responses[min(f.calls-1, len(f.responses)-1)]
+	return resp, nil
+}
+
+func response(status int, retryAfter string) *http.Response {
+	header := http.Header{}
+	if retryAfter != "" {
+		header.Set("Retry-After", retryAfter)
+	}
+	return &http.Response{StatusCode: status, Header: header, Body: io.NopCloser(strings.NewReader(""))}
+}
+
+func newTestTransport(next http.RoundTripper, recorded *[]time.Duration) rateLimitRetryTransport {
+	return rateLimitRetryTransport{
+		next:     next,
+		attempts: 3,
+		wait: func(_ context.Context, d time.Duration) error {
+			*recorded = append(*recorded, d)
+			return nil
+		},
+	}
+}
+
+func TestRoundTripPassesThroughNonRateLimited(t *testing.T) {
+	fake := &fakeRoundTripper{responses: []*http.Response{response(http.StatusOK, "")}}
+	var waits []time.Duration
+
+	resp, err := newTestTransport(fake, &waits).RoundTrip(httpGet(t))
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if fake.calls != 1 {
+		t.Errorf("calls = %d, want 1", fake.calls)
+	}
+	if len(waits) != 0 {
+		t.Errorf("waited %v, want no waiting", waits)
+	}
+}
+
+func TestRoundTripRetriesRateLimitedRequest(t *testing.T) {
+	fake := &fakeRoundTripper{responses: []*http.Response{
+		response(http.StatusTooManyRequests, ""),
+		response(http.StatusOK, ""),
+	}}
+	var waits []time.Duration
+
+	resp, err := newTestTransport(fake, &waits).RoundTrip(httpGet(t))
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200 after retry", resp.StatusCode)
+	}
+	if fake.calls != 2 {
+		t.Errorf("calls = %d, want 2", fake.calls)
+	}
+}
+
+func TestRoundTripHonoursRetryAfter(t *testing.T) {
+	fake := &fakeRoundTripper{responses: []*http.Response{
+		response(http.StatusTooManyRequests, "7"),
+		response(http.StatusOK, ""),
+	}}
+	var waits []time.Duration
+
+	if _, err := newTestTransport(fake, &waits).RoundTrip(httpGet(t)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(waits) != 1 || waits[0] != 7*time.Second {
+		t.Errorf("waits = %v, want [7s]", waits)
+	}
+}
+
+func TestRoundTripGivesUpAfterMaxAttempts(t *testing.T) {
+	fake := &fakeRoundTripper{responses: []*http.Response{response(http.StatusTooManyRequests, "")}}
+	var waits []time.Duration
+
+	resp, err := newTestTransport(fake, &waits).RoundTrip(httpGet(t))
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("status = %d, want the final 429 surfaced to the caller", resp.StatusCode)
+	}
+	if fake.calls != 4 {
+		t.Errorf("calls = %d, want 4 (initial + 3 retries)", fake.calls)
+	}
+}
+
+func TestRoundTripReplaysRequestBodyOnRetry(t *testing.T) {
+	fake := &fakeRoundTripper{responses: []*http.Response{
+		response(http.StatusTooManyRequests, ""),
+		response(http.StatusOK, ""),
+	}}
+	var waits []time.Duration
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "https://example.invalid/v3/routes", strings.NewReader("name=value"))
+	if err != nil {
+		t.Fatalf("building request: %v", err)
+	}
+
+	if _, err := newTestTransport(fake, &waits).RoundTrip(req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(fake.bodies) != 2 {
+		t.Fatalf("recorded %d bodies, want 2", len(fake.bodies))
+	}
+	if fake.bodies[0] != "name=value" || fake.bodies[1] != "name=value" {
+		t.Errorf("bodies = %v, want the payload replayed verbatim", fake.bodies)
+	}
+}
+
+func TestRoundTripDoesNotRetryUnreplayableBody(t *testing.T) {
+	fake := &fakeRoundTripper{responses: []*http.Response{response(http.StatusTooManyRequests, "")}}
+	var waits []time.Duration
+
+	req := httpGet(t)
+	req.Method = http.MethodPost
+	req.Body = io.NopCloser(strings.NewReader("streamed"))
+	req.GetBody = nil
+
+	resp, err := newTestTransport(fake, &waits).RoundTrip(req)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("status = %d, want the 429 surfaced without retry", resp.StatusCode)
+	}
+	if fake.calls != 1 {
+		t.Errorf("calls = %d, want 1 (body cannot be replayed)", fake.calls)
+	}
+}
+
+func TestRoundTripSurfacesTransportError(t *testing.T) {
+	wantErr := errors.New("dial failed")
+	fake := &fakeRoundTripper{err: wantErr}
+	var waits []time.Duration
+
+	if _, err := newTestTransport(fake, &waits).RoundTrip(httpGet(t)); !errors.Is(err, wantErr) {
+		t.Errorf("err = %v, want %v", err, wantErr)
+	}
+}
+
+func TestRoundTripAbortsWhenWaitFails(t *testing.T) {
+	fake := &fakeRoundTripper{responses: []*http.Response{response(http.StatusTooManyRequests, "")}}
+	transport := rateLimitRetryTransport{
+		next:     fake,
+		attempts: 3,
+		wait:     func(context.Context, time.Duration) error { return context.Canceled },
+	}
+
+	if _, err := transport.RoundTrip(httpGet(t)); !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want context.Canceled", err)
+	}
+}
+
+func TestRetryAfterDelay(t *testing.T) {
+	fallback := 2 * time.Second
+	tests := []struct {
+		name   string
+		header string
+		want   time.Duration
+	}{
+		{"absent", "", fallback},
+		{"seconds", "5", 5 * time.Second},
+		{"zero", "0", fallback},
+		{"negative", "-3", fallback},
+		{"unparseable", "later", fallback},
+		{"capped", "9999", maxRetryAfter},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := retryAfterDelay(tt.header, fallback); got != tt.want {
+				t.Errorf("retryAfterDelay(%q) = %v, want %v", tt.header, got, tt.want)
+			}
+		})
+	}
+}
+
+func httpGet(t *testing.T) *http.Request {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.invalid/v3/routes", nil)
+	if err != nil {
+		t.Fatalf("building request: %v", err)
+	}
+	return req
+}
+
+func TestSleepWithContextCompletes(t *testing.T) {
+	if err := sleepWithContext(context.Background(), time.Millisecond); err != nil {
+		t.Errorf("err = %v, want nil", err)
+	}
+}
+
+func TestSleepWithContextAbortsOnCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := sleepWithContext(ctx, time.Minute); !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want context.Canceled", err)
+	}
+}
+
+func TestNewRateLimitRetryTransportDefaults(t *testing.T) {
+	transport := newRateLimitRetryTransport()
+
+	if transport.attempts != rateLimitRetryAttempts {
+		t.Errorf("attempts = %d, want %d", transport.attempts, rateLimitRetryAttempts)
+	}
+	if transport.next != http.DefaultTransport {
+		t.Error("next should default to http.DefaultTransport")
+	}
+	if transport.wait == nil {
+		t.Error("wait must be set so RoundTrip can back off")
+	}
+}

--- a/internal/provider/retry_transport_test.go
+++ b/internal/provider/retry_transport_test.go
@@ -4,6 +4,7 @@
 package provider
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -375,14 +376,17 @@ func TestConfigureInstallsRetryTransport(t *testing.T) {
 	}
 }
 
-func TestRoundTripReusesConnectionAcrossRetries(t *testing.T) {
-	var newConns int32
-	var calls int32
+// newConnsForRetry drives a real transport through one 429 retry and reports how
+// many fresh connections the server saw.
+func newConnsForRetry(t *testing.T, rateLimitedBody []byte) int32 {
+	t.Helper()
+
+	var newConns, calls int32
 
 	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		if atomic.AddInt32(&calls, 1) == 1 {
 			w.WriteHeader(http.StatusTooManyRequests)
-			_, _ = io.WriteString(w, `{"message":"Too many requests"}`)
+			_, _ = w.Write(rateLimitedBody)
 			return
 		}
 		w.WriteHeader(http.StatusOK)
@@ -415,7 +419,20 @@ func TestRoundTripReusesConnectionAcrossRetries(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
-	if got := atomic.LoadInt32(&newConns); got != 1 {
+	return atomic.LoadInt32(&newConns)
+}
+
+func TestRoundTripReusesConnectionAcrossRetries(t *testing.T) {
+	if got := newConnsForRetry(t, []byte(`{"message":"Too many requests"}`)); got != 1 {
 		t.Errorf("new connections = %d, want 1: the discarded 429 body must be drained or net/http drops the connection", got)
+	}
+}
+
+func TestRoundTripDrainsUpToTheLimitOnly(t *testing.T) {
+	if got := newConnsForRetry(t, bytes.Repeat([]byte("x"), 4096)); got != 1 {
+		t.Errorf("new connections = %d, want 1 for a body exactly at the 4096 byte drain limit", got)
+	}
+	if got := newConnsForRetry(t, bytes.Repeat([]byte("x"), 4097)); got != 2 {
+		t.Errorf("new connections = %d, want 2 once the body exceeds the drain limit and cannot reach EOF", got)
 	}
 }

--- a/internal/provider/retry_transport_test.go
+++ b/internal/provider/retry_transport_test.go
@@ -11,6 +11,11 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/mailgun/mailgun-go/v5"
 )
 
 type fakeRoundTripper struct {
@@ -206,7 +211,8 @@ func TestRetryAfterDelay(t *testing.T) {
 		{"zero", "0", fallback},
 		{"negative", "-3", fallback},
 		{"unparseable", "later", fallback},
-		{"capped", "9999", maxRetryAfter},
+		{"one second", "1", time.Second},
+		{"capped", "9999", 30 * time.Second},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -245,13 +251,123 @@ func TestSleepWithContextAbortsOnCancelledContext(t *testing.T) {
 func TestNewRateLimitRetryTransportDefaults(t *testing.T) {
 	transport := newRateLimitRetryTransport()
 
-	if transport.attempts != rateLimitRetryAttempts {
-		t.Errorf("attempts = %d, want %d", transport.attempts, rateLimitRetryAttempts)
+	if transport.attempts != 3 {
+		t.Errorf("attempts = %d, want 3", transport.attempts)
 	}
 	if transport.next != http.DefaultTransport {
 		t.Error("next should default to http.DefaultTransport")
 	}
 	if transport.wait == nil {
 		t.Error("wait must be set so RoundTrip can back off")
+	}
+}
+
+type countingBody struct {
+	io.Reader
+	closes *int
+}
+
+func (b countingBody) Close() error {
+	*b.closes++
+	return nil
+}
+
+func TestRoundTripBacksOffExponentiallyWithoutRetryAfter(t *testing.T) {
+	fake := &fakeRoundTripper{responses: []*http.Response{
+		response(http.StatusTooManyRequests, ""),
+		response(http.StatusTooManyRequests, ""),
+		response(http.StatusOK, ""),
+	}}
+	var waits []time.Duration
+
+	if _, err := newTestTransport(fake, &waits).RoundTrip(httpGet(t)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(waits) != 2 || waits[0] != 2*time.Second || waits[1] != 4*time.Second {
+		t.Errorf("waits = %v, want [2s 4s] growing per attempt", waits)
+	}
+}
+
+func TestRoundTripClosesDiscardedResponseBodies(t *testing.T) {
+	var closes int
+	rateLimited := response(http.StatusTooManyRequests, "")
+	rateLimited.Body = countingBody{Reader: strings.NewReader(""), closes: &closes}
+
+	fake := &fakeRoundTripper{responses: []*http.Response{rateLimited, response(http.StatusOK, "")}}
+	var waits []time.Duration
+
+	if _, err := newTestTransport(fake, &waits).RoundTrip(httpGet(t)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if closes != 1 {
+		t.Errorf("closes = %d, want 1 so the discarded 429 body does not leak", closes)
+	}
+}
+
+func TestRoundTripPassesRequestContextToWait(t *testing.T) {
+	type marker struct{}
+	ctx := context.WithValue(context.Background(), marker{}, "carried")
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://example.invalid/v3/routes", nil)
+	if err != nil {
+		t.Fatalf("building request: %v", err)
+	}
+
+	fake := &fakeRoundTripper{responses: []*http.Response{
+		response(http.StatusTooManyRequests, ""),
+		response(http.StatusOK, ""),
+	}}
+	var seen context.Context
+	transport := rateLimitRetryTransport{
+		next:     fake,
+		attempts: 3,
+		wait: func(c context.Context, _ time.Duration) error {
+			seen = c
+			return nil
+		},
+	}
+
+	if _, err := transport.RoundTrip(req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if seen == nil || seen.Value(marker{}) != "carried" {
+		t.Error("wait must receive the request context so cancellation propagates")
+	}
+}
+
+func TestConfigureInstallsRetryTransport(t *testing.T) {
+	ctx := context.Background()
+
+	var schemaResp provider.SchemaResponse
+	(&mailgunProvider{}).Schema(ctx, provider.SchemaRequest{}, &schemaResp)
+
+	objType, ok := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	if !ok {
+		t.Fatal("provider schema type is not an object")
+	}
+
+	attrs := make(map[string]tftypes.Value, len(objType.AttributeTypes))
+	for name, attrType := range objType.AttributeTypes {
+		attrs[name] = tftypes.NewValue(attrType, nil)
+	}
+	attrs["api_key"] = tftypes.NewValue(tftypes.String, "key-test")
+
+	var resp provider.ConfigureResponse
+	(&mailgunProvider{}).Configure(ctx, provider.ConfigureRequest{
+		Config: tfsdk.Config{Raw: tftypes.NewValue(objType, attrs), Schema: schemaResp.Schema},
+	}, &resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+
+	client, ok := resp.ResourceData.(*mailgun.Client)
+	if !ok {
+		t.Fatalf("ResourceData = %T, want *mailgun.Client", resp.ResourceData)
+	}
+	if _, ok := client.HTTPClient().Transport.(rateLimitRetryTransport); !ok {
+		t.Errorf("transport = %T, want rateLimitRetryTransport so 429s are retried", client.HTTPClient().Transport)
 	}
 }

--- a/internal/provider/retry_transport_test.go
+++ b/internal/provider/retry_transport_test.go
@@ -7,8 +7,11 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net"
 	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -369,5 +372,50 @@ func TestConfigureInstallsRetryTransport(t *testing.T) {
 	}
 	if _, ok := client.HTTPClient().Transport.(rateLimitRetryTransport); !ok {
 		t.Errorf("transport = %T, want rateLimitRetryTransport so 429s are retried", client.HTTPClient().Transport)
+	}
+}
+
+func TestRoundTripReusesConnectionAcrossRetries(t *testing.T) {
+	var newConns int32
+	var calls int32
+
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = io.WriteString(w, `{"message":"Too many requests"}`)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			atomic.AddInt32(&newConns, 1)
+		}
+	}
+	server.Start()
+	defer server.Close()
+
+	transport := rateLimitRetryTransport{
+		next:     &http.Transport{},
+		attempts: 3,
+		wait:     func(context.Context, time.Duration) error { return nil },
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatalf("building request: %v", err)
+	}
+
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := atomic.LoadInt32(&newConns); got != 1 {
+		t.Errorf("new connections = %d, want 1: the discarded 429 body must be drained or net/http drops the connection", got)
 	}
 }


### PR DESCRIPTION
Two coupled changes: acceptance tests have never actually run in CI, and turning them on exposes a missing 429 retry.

## The acceptance suite was silently skipping

`test.yml` provides `MAILGUN_API_KEY` but never `MAILGUN_TEST_DOMAIN`. Every acceptance test that needs a domain starts with:

```go
domainName := os.Getenv("MAILGUN_TEST_DOMAIN")
if domainName == "" {
    t.Skip("MAILGUN_TEST_DOMAIN environment variable is not set")
}
```

**Ten packages** gate on that variable, including `smtp_credentials`, `domains`, `webhooks`, `templates`, `mailing_lists`, `domain_dkim_key`, `domain_ip`, `domain_sending_keys`, `domain_tracking` and `mailing_list_members`. `go test` still reports `ok` for a skip, so CI has been green while spending two full Terraform-matrix legs running almost no acceptance coverage.

This wires the variable through as `vars.MAILGUN_TEST_DOMAIN` (a repo variable, not a secret; the sandbox domain name is not a credential).

## Which exposed a missing 429 retry

The provider had no rate-limit handling. `mailgun.NewMailgun` defaults to `http.DefaultClient`, and a bare 429 reached practitioners as a hard apply failure.

With the ten packages enabled, the added API volume made `TestAccRoutesDataSource_WithLimit` fail **reproducibly** in two consecutive full runs, while passing in isolation after a cooldown:

| Run | `routes` |
| --- | --- |
| Full suite (1st) | FAIL — 429 on `GET /v3/routes` |
| `routes` alone, immediately after | FAIL — residual limit |
| `routes` alone, after cooldown | PASS |
| Full suite (2nd, after cooldown) | FAIL — same test, same 429 |

This is not test-only flakiness. Anyone applying a moderately sized configuration against a rate-limited account hits the same wall with no retry.

`rateLimitRetryTransport` wraps the client transport and retries 429 up to three times, honouring `Retry-After` (whole seconds, capped at 30s) and otherwise backing off exponentially from 2s. Requests whose body cannot be replayed via `GetBody` are not retried, and the wait respects context cancellation.

## Verification

- Full acceptance suite green **four consecutive times** with the retry in place (`routes` ~21-23s as it waits out the limit; ~136s total against CI's 10 minute cap)
- `go build`, `go vet`, `gofmt`, full unit suite clean; `golangci-lint` 0 issues
- CRAP gate `COMMIT_OK`; every new function OK (`RoundTrip` 6.0, `rewindBody` 4.0, `retryAfterDelay` 3.0, rest lower)
- Mutation gate **`MUTATION_OK`, 0 survivors** on the changed lines

## Note for reviewers

The SDK default was `http.DefaultClient`, which has no timeout, so swapping the transport regresses nothing. Per-operation timeouts already come from `context.WithTimeout` in each resource.

Turning the acceptance suite on may surface pre-existing failures in resources that have never been exercised in CI. All sixteen packages pass locally, but they run against a single sandbox domain.

Found while reviewing #76. Related: #83.