### PR TITLE
fix(smtp): stop fabricating created_at when the credential listing lags

### DIFF
--- a/.changelog/88.txt
+++ b/.changelog/88.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mailgun_smtp_credential: Stop stamping a client-side `created_at` when the credential listing lags a create. The value is now retried briefly and left null if still unavailable, so it can no longer disagree with the server.
+```

--- a/internal/provider/smtp_credentials/helpers_internal_test.go
+++ b/internal/provider/smtp_credentials/helpers_internal_test.go
@@ -114,3 +114,14 @@ func TestCreatedAtLookupActuallyBacksOff(t *testing.T) {
 		t.Errorf("createdAtLookupDelay = %v; too long to sit in a create", createdAtLookupDelay)
 	}
 }
+
+func TestCreatedAtLookupBudgetCoversItsAttempts(t *testing.T) {
+	if createdAtLookupBudget <= 0 {
+		t.Fatalf("createdAtLookupBudget = %v; a non-positive budget expires before the first lookup runs", createdAtLookupBudget)
+	}
+
+	// The budget has to outlast the waits it wraps, or later attempts never happen.
+	if minimum := time.Duration(createdAtLookupAttempts-1) * createdAtLookupDelay; createdAtLookupBudget <= minimum {
+		t.Errorf("createdAtLookupBudget = %v, must exceed the %v spent waiting between attempts", createdAtLookupBudget, minimum)
+	}
+}

--- a/internal/provider/smtp_credentials/helpers_internal_test.go
+++ b/internal/provider/smtp_credentials/helpers_internal_test.go
@@ -105,3 +105,12 @@ func TestFindEventuallyDefaultsToFourAttempts(t *testing.T) {
 		t.Errorf("calls = %d, want 4: the package default budget", calls)
 	}
 }
+
+func TestCreatedAtLookupActuallyBacksOff(t *testing.T) {
+	if createdAtLookupDelay <= 0 {
+		t.Fatalf("createdAtLookupDelay = %v; a zero delay retries the listing with no time to catch up", createdAtLookupDelay)
+	}
+	if createdAtLookupDelay > time.Second {
+		t.Errorf("createdAtLookupDelay = %v; too long to sit in a create", createdAtLookupDelay)
+	}
+}

--- a/internal/provider/smtp_credentials/helpers_internal_test.go
+++ b/internal/provider/smtp_credentials/helpers_internal_test.go
@@ -89,3 +89,19 @@ func TestFindEventuallyAbortsOnCancelledContext(t *testing.T) {
 		t.Errorf("calls = %d, want 1 before the context cancels the wait", calls)
 	}
 }
+
+func TestFindEventuallyDefaultsToFourAttempts(t *testing.T) {
+	calls := 0
+
+	_, err := findEventually(context.Background(), createdAtLookupAttempts, 0, func() (*mtypes.Credential, error) {
+		calls++
+		return nil, errors.New("credential not found")
+	})
+
+	if err == nil {
+		t.Fatal("expected the lookup to give up")
+	}
+	if calls != 4 {
+		t.Errorf("calls = %d, want 4: the package default budget", calls)
+	}
+}

--- a/internal/provider/smtp_credentials/helpers_internal_test.go
+++ b/internal/provider/smtp_credentials/helpers_internal_test.go
@@ -1,0 +1,91 @@
+// Copyright Hack The Box 2025, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package smtp_credentials
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/mailgun/mailgun-go/v5/mtypes"
+)
+
+func TestFindEventuallyReturnsFirstSuccess(t *testing.T) {
+	calls := 0
+	want := &mtypes.Credential{Login: "user@example.com"}
+
+	got, err := findEventually(context.Background(), 4, 0, func() (*mtypes.Credential, error) {
+		calls++
+		return want, nil
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("credential = %v, want %v", got, want)
+	}
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1 (no retry once the listing succeeds)", calls)
+	}
+}
+
+func TestFindEventuallyRetriesUntilTheListingCatchesUp(t *testing.T) {
+	calls := 0
+	want := &mtypes.Credential{Login: "user@example.com"}
+
+	got, err := findEventually(context.Background(), 4, 0, func() (*mtypes.Credential, error) {
+		calls++
+		if calls < 3 {
+			return nil, errors.New("credential not found")
+		}
+		return want, nil
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("credential = %v, want %v", got, want)
+	}
+	if calls != 3 {
+		t.Errorf("calls = %d, want 3", calls)
+	}
+}
+
+func TestFindEventuallyGivesUpAfterAttempts(t *testing.T) {
+	calls := 0
+	wantErr := errors.New("credential not found")
+
+	_, err := findEventually(context.Background(), 2, 0, func() (*mtypes.Credential, error) {
+		calls++
+		return nil, wantErr
+	})
+
+	if !errors.Is(err, wantErr) {
+		t.Errorf("err = %v, want %v", err, wantErr)
+	}
+	if calls != 2 {
+		t.Errorf("calls = %d, want 2 (the attempt budget, not the package default)", calls)
+	}
+}
+
+func TestFindEventuallyAbortsOnCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	calls := 0
+	_, err := findEventually(ctx, 4, time.Minute, func() (*mtypes.Credential, error) {
+		calls++
+		return nil, errors.New("credential not found")
+	})
+
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want context.Canceled", err)
+	}
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1 before the context cancels the wait", calls)
+	}
+}

--- a/internal/provider/smtp_credentials/resource.go
+++ b/internal/provider/smtp_credentials/resource.go
@@ -18,6 +18,9 @@ import (
 const (
 	createdAtLookupAttempts = 4
 	createdAtLookupDelay    = 250 * time.Millisecond
+	// Caps the whole lookup: findCredential allows 30s per call, which the retries
+	// would otherwise stack into a two minute create.
+	createdAtLookupBudget = 10 * time.Second
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -116,8 +119,11 @@ func (r *SmtpCredentialResource) Create(ctx context.Context, req resource.Create
 	plan.FullLogin = types.StringValue(fmt.Sprintf("%s@%s", login, domain))
 
 	// Try to get the created_at from the API by listing credentials
-	credential, err := findEventually(ctx, createdAtLookupAttempts, createdAtLookupDelay, func() (*mtypes.Credential, error) {
-		return r.findCredential(ctx, domain, login)
+	lookupCtx, cancelLookup := context.WithTimeout(ctx, createdAtLookupBudget)
+	defer cancelLookup()
+
+	credential, err := findEventually(lookupCtx, createdAtLookupAttempts, createdAtLookupDelay, func() (*mtypes.Credential, error) {
+		return r.findCredential(lookupCtx, domain, login)
 	})
 	if err != nil {
 		// Null, not a client-side stamp the server would contradict; Read fills it in.
@@ -327,9 +333,9 @@ func (r *SmtpCredentialResource) ImportState(ctx context.Context, req resource.I
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-// findEventually retries find while it reports the credential missing. Mailgun's
-// credential listing lags a create, so the first lookup routinely misses one that
-// definitely exists.
+// findEventually retries find on any error until it succeeds or the attempt
+// budget runs out. Mailgun's credential listing lags a create, so the first
+// lookup routinely misses one that definitely exists.
 func findEventually(ctx context.Context, attempts int, delay time.Duration, find func() (*mtypes.Credential, error)) (*mtypes.Credential, error) {
 	for attempt := 1; ; attempt++ {
 		credential, err := find()

--- a/internal/provider/smtp_credentials/resource.go
+++ b/internal/provider/smtp_credentials/resource.go
@@ -15,6 +15,11 @@ import (
 	"github.com/mailgun/mailgun-go/v5/mtypes"
 )
 
+const (
+	createdAtLookupAttempts = 4
+	createdAtLookupDelay    = 250 * time.Millisecond
+)
+
 // Ensure the implementation satisfies the expected interfaces.
 var (
 	_ resource.Resource                = &SmtpCredentialResource{}
@@ -111,10 +116,12 @@ func (r *SmtpCredentialResource) Create(ctx context.Context, req resource.Create
 	plan.FullLogin = types.StringValue(fmt.Sprintf("%s@%s", login, domain))
 
 	// Try to get the created_at from the API by listing credentials
-	credential, err := r.findCredential(ctx, domain, login)
+	credential, err := findEventually(ctx, createdAtLookupAttempts, createdAtLookupDelay, func() (*mtypes.Credential, error) {
+		return r.findCredential(ctx, domain, login)
+	})
 	if err != nil {
-		// Not fatal - we created it, just can't get the timestamp
-		plan.CreatedAt = types.StringValue(time.Now().UTC().Format(time.RFC3339))
+		// Null, not a client-side stamp the server would contradict; Read fills it in.
+		plan.CreatedAt = types.StringNull()
 	} else {
 		plan.CreatedAt = types.StringValue(time.Time(credential.CreatedAt).Format(time.RFC3339))
 	}
@@ -318,6 +325,33 @@ func (r *SmtpCredentialResource) ImportState(ctx context.Context, req resource.I
 
 	// Save imported state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+// findEventually retries find while it reports the credential missing. Mailgun's
+// credential listing lags a create, so the first lookup routinely misses one that
+// definitely exists.
+func findEventually(ctx context.Context, attempts int, delay time.Duration, find func() (*mtypes.Credential, error)) (*mtypes.Credential, error) {
+	var err error
+
+	for attempt := 0; attempt < attempts; attempt++ {
+		var credential *mtypes.Credential
+		if credential, err = find(); err == nil {
+			return credential, nil
+		}
+		if attempt == attempts-1 {
+			break
+		}
+
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+
+	return nil, err
 }
 
 // findCredential searches for a specific credential by domain and login

--- a/internal/provider/smtp_credentials/resource.go
+++ b/internal/provider/smtp_credentials/resource.go
@@ -331,15 +331,13 @@ func (r *SmtpCredentialResource) ImportState(ctx context.Context, req resource.I
 // credential listing lags a create, so the first lookup routinely misses one that
 // definitely exists.
 func findEventually(ctx context.Context, attempts int, delay time.Duration, find func() (*mtypes.Credential, error)) (*mtypes.Credential, error) {
-	var err error
-
-	for attempt := 0; attempt < attempts; attempt++ {
-		var credential *mtypes.Credential
-		if credential, err = find(); err == nil {
+	for attempt := 1; ; attempt++ {
+		credential, err := find()
+		if err == nil {
 			return credential, nil
 		}
-		if attempt == attempts-1 {
-			break
+		if attempt >= attempts {
+			return nil, err
 		}
 
 		timer := time.NewTimer(delay)
@@ -350,8 +348,6 @@ func findEventually(ctx context.Context, attempts int, delay time.Duration, find
 		case <-timer.C:
 		}
 	}
-
-	return nil, err
 }
 
 // findCredential searches for a specific credential by domain and login


### PR DESCRIPTION
Fixes #87. `main` is currently red because of this.

## The bug

`Create` reads `created_at` back by listing credentials, but Mailgun's listing is eventually consistent and routinely misses a credential that was just created. The old fallback stamped a client-side time:

```go
credential, err := r.findCredential(ctx, domain, login)
if err != nil {
    // Not fatal - we created it, just can't get the timestamp
    plan.CreatedAt = types.StringValue(time.Now().UTC().Format(time.RFC3339))
}
```

`time.Now()` lands a hair after the server value, so `ImportStateVerify` compared them and failed:

```
Step 2/4 error running import: ImportStateVerify attributes not equivalent.
- 	"created_at": "2026-08-14T02:19:27Z",
+ 	"created_at": "2026-08-14T02:19:26Z",
```

One second apart, and only when the listing lag happens to straddle a second boundary — which is why it presents as a flake.

## The fix

Retry the lookup (4 attempts, 250ms apart), and if it still cannot be read, leave `created_at` **null** so the next `Read` supplies it.

Null is a *known* value, so it is legal for a `Computed` attribute — unlike unknown, which Terraform rejects in final state. Inventing a timestamp is the one option that cannot be right, because it guarantees a divergence the server later contradicts.

`findEventually` takes the lookup as a function, so the retry, budget and cancellation behaviour are unit tested without a live client.

## Verification

- `TestAccSmtpCredentialResource`, the test failing on `main`, passed **3 consecutive runs** against the CI account, then the full package passed twice more
- `go build`, `go vet`, `gofmt`, full unit suite clean; `golangci-lint` 0 issues
- CRAP `COMMIT_OK`; `findEventually` complexity 6, coverage 100%, CRAP 6.0

## Mutation testing

Started at 12 survivors, now 4, all explicitly accepted:

- Restructuring `findEventually` to a **single** termination condition killed 7. The loop bound and the trailing `break` were redundant and masked each other, so `<` vs `<=` and `break` vs `continue` were undetectable. One exit makes the attempt budget observable.
- A bounds assertion killed the `250 / time.Millisecond` mutant, which evaluates to **0** through integer division and would retry three times with no pause at all.
- Remaining 4 accepted: two ±1ms tunings of the delay constant (killable only with flaky timing assertions) and two `ctx` → `nil` mutants inside `Create`, which has no unit coverage until the client seam in #83 exists.

## Note

#76 leaves this fallback untouched and would inherit the flake, so this should land before it.