### PR TITLE
docs(changelog): prepare v1.1.0

### DIFF
--- a/.changelog/76.txt
+++ b/.changelog/76.txt
@@ -1,7 +1,0 @@
-```release-note:enhancement
-resource/mailgun_smtp_credential: Add write-only `password_wo` and `password_wo_version` arguments. The secret is never stored in Terraform state; increment the version to rotate. Requires Terraform CLI >= 1.11.
-```
-
-```release-note:deprecation
-resource/mailgun_smtp_credential: The `password` argument is deprecated in favor of `password_wo`/`password_wo_version` and will be removed in a future major release.
-```

--- a/.changelog/77.txt
+++ b/.changelog/77.txt
@@ -1,3 +1,0 @@
-```release-note:enhancement
-provider: The `api_key` argument is now optional and falls back to the `MAILGUN_API_KEY` environment variable, matching the documented behaviour. Configuring `api_key` with a value that is unknown until apply is now an error rather than a silent fall back to the environment.
-```

--- a/.changelog/84.txt
+++ b/.changelog/84.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-provider: Retry requests that Mailgun rejects with HTTP 429, honouring `Retry-After` (capped at 30s) with exponential backoff. Previously a rate-limited response surfaced as a hard apply failure.
-```

--- a/.changelog/88.txt
+++ b/.changelog/88.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-resource/mailgun_smtp_credential: Stop stamping a client-side `created_at` when the credential listing lags a create. The value is now retried briefly and left null if still unavailable, so it can no longer disagree with the server.
-```

--- a/.changelog/89.txt
+++ b/.changelog/89.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-resource/mailgun_domain_tracking: Stop overwriting configured attributes with the post-apply read. A read that disagrees with the configuration now surfaces as drift on the next refresh instead of failing the apply with "Provider produced inconsistent result after apply".
-```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 1.1.0 (August 14, 2026)
+
+DEPRECATIONS:
+* resource/mailgun_smtp_credential: The `password` argument is deprecated in favor of `password_wo`/`password_wo_version` and will be removed in a future major release. ([#76](https://github.com/hackthebox/terraform-provider-mailgun/pull/76))
+
+ENHANCEMENTS:
+* provider: The `api_key` argument is now optional and falls back to the `MAILGUN_API_KEY` environment variable, matching the documented behaviour. Configuring `api_key` with a value that is unknown until apply is now an error rather than a silent fall back to the environment. ([#77](https://github.com/hackthebox/terraform-provider-mailgun/pull/77))
+* resource/mailgun_smtp_credential: Add write-only `password_wo` and `password_wo_version` arguments. The secret is never stored in Terraform state; increment the version to rotate. Requires Terraform CLI >= 1.11. ([#76](https://github.com/hackthebox/terraform-provider-mailgun/pull/76))
+
+BUG FIXES:
+* provider: Retry requests that Mailgun rejects with HTTP 429, honouring `Retry-After` (capped at 30s) with exponential backoff. Previously a rate-limited response surfaced as a hard apply failure. ([#84](https://github.com/hackthebox/terraform-provider-mailgun/pull/84))
+* resource/mailgun_domain_tracking: Stop overwriting configured attributes with the post-apply read. A read that disagrees with the configuration now surfaces as drift on the next refresh instead of failing the apply with "Provider produced inconsistent result after apply". ([#89](https://github.com/hackthebox/terraform-provider-mailgun/pull/89))
+* resource/mailgun_smtp_credential: Stop stamping a client-side `created_at` when the credential listing lags a create. The value is now retried briefly and left null if still unavailable, so it can no longer disagree with the server. ([#88](https://github.com/hackthebox/terraform-provider-mailgun/pull/88))
+
 ## 1.0.6 (June 12, 2026)
 
 BUG FIXES:


### PR DESCRIPTION
## Summary

Prepares the `v1.1.0` release. Rolls the five pending `.changelog` entries into `CHANGELOG.md` and removes the now-released entry files, matching the process used for `v1.0.6` (#68).

Minor bump rather than a patch: #76 adds new arguments and deprecates an existing one, both backward compatible.

## Contents

| PR | Type |
|----|------|
| #76 | enhancement + deprecation (write-only SMTP password) |
| #77 | enhancement (`api_key` optional, `MAILGUN_API_KEY` fallback) |
| #84 | bug (429 retry with `Retry-After`) |
| #88 | bug (no fabricated `created_at`) |
| #89 | bug (`domain_tracking` plan consistency) |

Generated with `changelog-build` using the `.changelog/` templates. Note that the older `.ci/scripts/{changelog,release-note}.tmpl` pair is stale: it links to `/issues/` instead of `/pull/` and has no `deprecation` section, so it would have silently dropped #76's deprecation notice. Worth deleting separately.

Once merged, tagging `v1.1.0` triggers the GoReleaser workflow.

## Test plan

Docs only, no code changes.
