### PR TITLE
docs(changelog): prepare v1.1.1

### DIFF
--- a/.changelog/94.txt
+++ b/.changelog/94.txt
@@ -1,3 +1,0 @@
-```release-note:enhancement
-provider: Upgraded the Mailgun SDK (`mailgun-go/v5`) from v5.16.0 to v5.19.1.
-```

--- a/.changelog/97.txt
+++ b/.changelog/97.txt
@@ -1,3 +1,0 @@
-```release-note:note
-provider: Built with Go 1.25.13 (was 1.25.8) and `golang.org/x/text` v0.39.0, patching six vulnerabilities reachable from the provider's own call graph: GO-2026-6218, GO-2026-6090, GO-2026-5972, GO-2026-5970, GO-2026-5856 and GO-2026-5026. Releases up to and including v1.1.0 are affected. Building the provider from source now requires Go 1.25.13 or later.
-```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.1.1 (August 14, 2026)
+
+NOTES:
+* provider: Built with Go 1.25.13 (was 1.25.8) and `golang.org/x/text` v0.39.0, patching six vulnerabilities reachable from the provider's own call graph: GO-2026-6218, GO-2026-6090, GO-2026-5972, GO-2026-5970, GO-2026-5856 and GO-2026-5026. Releases up to and including v1.1.0 are affected. Building the provider from source now requires Go 1.25.13 or later. ([#97](https://github.com/hackthebox/terraform-provider-mailgun/pull/97))
+
+ENHANCEMENTS:
+* provider: Upgraded the Mailgun SDK (`mailgun-go/v5`) from v5.16.0 to v5.19.1. ([#94](https://github.com/hackthebox/terraform-provider-mailgun/pull/94))
+
 ## 1.1.0 (August 14, 2026)
 
 DEPRECATIONS:


### PR DESCRIPTION
## Summary

Prepares `v1.1.1`. Rolls the two pending `.changelog` entries into `CHANGELOG.md` and removes the released entry files, matching the process used for v1.1.0 (#90).

**This is a security patch release.** v1.1.0 binaries contain six vulnerabilities reachable from the provider's own call graph, fixed on main by #97. That is the reason to ship now rather than wait for the next feature release.

## Contents

| PR | Type |
|----|------|
| #97 | note (Go 1.25.13 + `x/text` v0.39.0, six reachable CVEs patched) |
| #94 | enhancement (Mailgun SDK v5.16.0 → v5.19.1) |

Patch rather than minor: the only ENHANCEMENTS line is an SDK upgrade that adds no provider surface, and patch releases in this repo already carry enhancements (see 1.0.2 and 1.0.3).

Not in the release notes, because they are CI-only with no user-facing effect: #93, #95, #96.

Once merged, tagging `v1.1.1` triggers GoReleaser.

## Test plan

Docs only, no code changes. Generated with `changelog-build` against the `.changelog/` templates.
