### PR TITLE
chore: ignore the local Go cache and audit output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,10 @@ website/vendor
 *.winfile eol=crlf
 
 mise.local.toml
+
+# Local Go build cache, when GOCACHE is pointed inside the repo
+.gocache/
+
+# Output of scripts/mailgun-audit.sh: an inventory of production domains,
+# SMTP logins and requestor addresses. This repo is public.
+audit/


### PR DESCRIPTION
## Summary

Two directories were sitting untracked and un-ignored in the working tree, so they appeared in every `git status` and a `git add -A` would have committed them to a public repo.

**`.gocache/`** — 346M of regenerable Go build cache, from `GOCACHE` being pointed inside the repo. Nothing in the repo references it (checked `GNUmakefile`, `mise.toml`, `.golangci.yml`).

**`audit/`** — output of `scripts/mailgun-audit.sh`, an inventory of production Mailgun domains, SMTP logins and requestor addresses.

Added alongside the existing `mise.local.toml` entry, which set the precedent for ignoring local artifacts in the tracked `.gitignore`.

## On `audit/`, since the filenames look alarming

I checked before assuming. `us_credentials.json` and `eu_credentials.json` hold `mailbox` / `login` / `created_at` only, with no password field, which matches Mailgun never returning SMTP passwords. `*_keys.json` is DKIM signing domains, selectors and DNS records. `*_sending_keys.json` is key metadata (id, description, kind, role, timestamps, requestor) with no key material.

So it is a production inventory, not a credential leak, and `git log --all` confirms none of it was ever committed. Still not something to publish from a public repo, and ignoring it is what makes the generator script safe to keep.

## Test plan

`.gitignore` only, no code changes. Verified `git status` is clean afterwards apart from `scripts/`, which is a separate decision.
