### PR TITLE
feat: validate resource schema inputs

### DIFF
--- a/.changelog/104.txt
+++ b/.changelog/104.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/mailgun_ip_allowlist: Validate IP and CIDR syntax during planning; also validate related dedicated-IP, DKIM key-size, and mailing-list email fields.
+```

--- a/internal/provider/domain_dkim_key/resource_schema.go
+++ b/internal/provider/domain_dkim_key/resource_schema.go
@@ -4,12 +4,14 @@
 package domain_dkim_key
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
 // DomainDkimKeyResourceSchema returns the schema for the mailgun_domain_dkim_key resource.
@@ -44,6 +46,9 @@ func DomainDkimKeyResourceSchema() schema.Schema {
 				Optional:    true,
 				Computed:    true,
 				Default:     int64default.StaticInt64(1024),
+				Validators: []validator.Int64{
+					int64validator.OneOf(1024, 2048),
+				},
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.RequiresReplace(),
 				},

--- a/internal/provider/domain_ip/resource_schema.go
+++ b/internal/provider/domain_ip/resource_schema.go
@@ -7,6 +7,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/hackthebox/terraform-provider-mailgun/internal/provider/schema_validators"
 )
 
 // DomainIPResourceSchema returns the schema for the mailgun_domain_ip resource.
@@ -32,6 +35,9 @@ func DomainIPResourceSchema() schema.Schema {
 			"ip": schema.StringAttribute{
 				Description: "The IP address to associate with the domain.",
 				Required:    true,
+				Validators: []validator.String{
+					schema_validators.IPAddress(),
+				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},

--- a/internal/provider/ip_allowlist/resource_schema.go
+++ b/internal/provider/ip_allowlist/resource_schema.go
@@ -8,6 +8,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/hackthebox/terraform-provider-mailgun/internal/provider/schema_validators"
 )
 
 // IPAllowlistResourceSchema returns the schema for the mailgun_ip_allowlist resource.
@@ -19,6 +22,9 @@ func IPAllowlistResourceSchema() schema.Schema {
 			"address": schema.StringAttribute{
 				Description: "The IP address or CIDR range to allowlist (e.g., '192.168.1.1' or '192.168.1.0/24').",
 				Required:    true,
+				Validators: []validator.String{
+					schema_validators.IPAddressOrCIDR(),
+				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},

--- a/internal/provider/mailing_list_members/resource_schema.go
+++ b/internal/provider/mailing_list_members/resource_schema.go
@@ -8,7 +8,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/hackthebox/terraform-provider-mailgun/internal/provider/schema_validators"
 )
 
 // MailingListMemberResourceSchema returns the schema for the mailgun_mailing_list_member resource.
@@ -20,6 +23,9 @@ func MailingListMemberResourceSchema() schema.Schema {
 			"list_address": schema.StringAttribute{
 				Description: "The email address of the mailing list. Changing this forces recreation.",
 				Required:    true,
+				Validators: []validator.String{
+					schema_validators.EmailAddress(),
+				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -27,6 +33,9 @@ func MailingListMemberResourceSchema() schema.Schema {
 			"member_address": schema.StringAttribute{
 				Description: "The email address of the member. Changing this forces recreation.",
 				Required:    true,
+				Validators: []validator.String{
+					schema_validators.EmailAddress(),
+				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},

--- a/internal/provider/schema_validators/string.go
+++ b/internal/provider/schema_validators/string.go
@@ -1,0 +1,88 @@
+// Copyright Hack The Box 2025, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package schema_validators
+
+import (
+	"context"
+	"fmt"
+	"net/mail"
+	"net/netip"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+var _ validator.String = stringValueValidator{}
+
+type stringValueValidator struct {
+	description string
+	isValid     func(string) bool
+}
+
+func (v stringValueValidator) Description(context.Context) string {
+	return v.description
+}
+
+func (v stringValueValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v stringValueValidator) ValidateString(
+	_ context.Context,
+	request validator.StringRequest,
+	response *validator.StringResponse,
+) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	value := request.ConfigValue.ValueString()
+	if v.isValid(value) {
+		return
+	}
+
+	response.Diagnostics.AddAttributeError(
+		request.Path,
+		"Invalid Attribute Value",
+		fmt.Sprintf("Value %q is invalid: %s.", value, v.description),
+	)
+}
+
+// IPAddress returns a validator that accepts IPv4 and IPv6 addresses.
+func IPAddress() validator.String {
+	return stringValueValidator{
+		description: "value must be a valid IPv4 or IPv6 address",
+		isValid:     isIPAddress,
+	}
+}
+
+// IPAddressOrCIDR returns a validator that accepts IP addresses and CIDR prefixes.
+func IPAddressOrCIDR() validator.String {
+	return stringValueValidator{
+		description: "value must be a valid IPv4 or IPv6 address or CIDR prefix",
+		isValid: func(value string) bool {
+			if isIPAddress(value) {
+				return true
+			}
+
+			prefix, err := netip.ParsePrefix(value)
+			return err == nil && prefix.Addr().Zone() == ""
+		},
+	}
+}
+
+// EmailAddress returns a validator that accepts an email address without a display name.
+func EmailAddress() validator.String {
+	return stringValueValidator{
+		description: "value must be a valid email address without a display name",
+		isValid: func(value string) bool {
+			address, err := mail.ParseAddress(value)
+			return err == nil && address.Address == value
+		},
+	}
+}
+
+func isIPAddress(value string) bool {
+	address, err := netip.ParseAddr(value)
+	return err == nil && address.Zone() == ""
+}

--- a/internal/provider/schema_validators/string_test.go
+++ b/internal/provider/schema_validators/string_test.go
@@ -1,0 +1,238 @@
+// Copyright Hack The Box 2025, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package schema_validators_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/hackthebox/terraform-provider-mailgun/internal/provider/domain_dkim_key"
+	"github.com/hackthebox/terraform-provider-mailgun/internal/provider/domain_ip"
+	"github.com/hackthebox/terraform-provider-mailgun/internal/provider/ip_allowlist"
+	"github.com/hackthebox/terraform-provider-mailgun/internal/provider/mailing_list_members"
+	"github.com/hackthebox/terraform-provider-mailgun/internal/provider/schema_validators"
+)
+
+func TestStringValidators(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		validator validator.String
+		value     types.String
+		wantError bool
+	}{
+		{
+			name:      "IPv4 address",
+			validator: schema_validators.IPAddress(),
+			value:     types.StringValue("192.0.2.1"),
+		},
+		{
+			name:      "IPv6 address",
+			validator: schema_validators.IPAddress(),
+			value:     types.StringValue("2001:db8::1"),
+		},
+		{
+			name:      "CIDR is not a bare address",
+			validator: schema_validators.IPAddress(),
+			value:     types.StringValue("192.0.2.0/24"),
+			wantError: true,
+		},
+		{
+			name:      "invalid IP address",
+			validator: schema_validators.IPAddress(),
+			value:     types.StringValue("192.0.2.999"),
+			wantError: true,
+		},
+		{
+			name:      "IPv4 CIDR",
+			validator: schema_validators.IPAddressOrCIDR(),
+			value:     types.StringValue("192.0.2.0/24"),
+		},
+		{
+			name:      "bare IP is accepted by IP-or-CIDR validator",
+			validator: schema_validators.IPAddressOrCIDR(),
+			value:     types.StringValue("192.0.2.1"),
+		},
+		{
+			name:      "IPv6 CIDR",
+			validator: schema_validators.IPAddressOrCIDR(),
+			value:     types.StringValue("2001:db8::/32"),
+		},
+		{
+			name:      "invalid CIDR prefix length",
+			validator: schema_validators.IPAddressOrCIDR(),
+			value:     types.StringValue("192.0.2.0/33"),
+			wantError: true,
+		},
+		{
+			name:      "hostname is not an IP address or CIDR",
+			validator: schema_validators.IPAddressOrCIDR(),
+			value:     types.StringValue("example.com"),
+			wantError: true,
+		},
+		{
+			name:      "email address",
+			validator: schema_validators.EmailAddress(),
+			value:     types.StringValue("member+tag@example.com"),
+		},
+		{
+			name:      "display name is not a plain email address",
+			validator: schema_validators.EmailAddress(),
+			value:     types.StringValue("Member <member@example.com>"),
+			wantError: true,
+		},
+		{
+			name:      "invalid email address",
+			validator: schema_validators.EmailAddress(),
+			value:     types.StringValue("member.example.com"),
+			wantError: true,
+		},
+		{
+			name:      "null values are deferred",
+			validator: schema_validators.IPAddress(),
+			value:     types.StringNull(),
+		},
+		{
+			name:      "unknown values are deferred",
+			validator: schema_validators.EmailAddress(),
+			value:     types.StringUnknown(),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var response validator.StringResponse
+			test.validator.ValidateString(context.Background(), validator.StringRequest{
+				Path:        path.Root("value"),
+				ConfigValue: test.value,
+			}, &response)
+
+			if got := response.Diagnostics.HasError(); got != test.wantError {
+				t.Fatalf("HasError() = %t, want %t; diagnostics: %v", got, test.wantError, response.Diagnostics)
+			}
+		})
+	}
+}
+
+func TestResourceSchemasWireValidators(t *testing.T) {
+	t.Parallel()
+
+	stringTests := []struct {
+		name       string
+		attribute  rschema.Attribute
+		validValue string
+		badValue   string
+	}{
+		{
+			name:       "IP allowlist address",
+			attribute:  ip_allowlist.IPAllowlistResourceSchema().Attributes["address"],
+			validValue: "192.0.2.0/24",
+			badValue:   "192.0.2.999",
+		},
+		{
+			name:       "domain IP address",
+			attribute:  domain_ip.DomainIPResourceSchema().Attributes["ip"],
+			validValue: "2001:db8::1",
+			badValue:   "example.com",
+		},
+		{
+			name:       "mailing list address",
+			attribute:  mailing_list_members.MailingListMemberResourceSchema().Attributes["list_address"],
+			validValue: "list@example.com",
+			badValue:   "list.example.com",
+		},
+		{
+			name:       "mailing list member address",
+			attribute:  mailing_list_members.MailingListMemberResourceSchema().Attributes["member_address"],
+			validValue: "member@example.com",
+			badValue:   "member.example.com",
+		},
+	}
+
+	for _, test := range stringTests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			attribute, ok := test.attribute.(rschema.StringAttribute)
+			if !ok {
+				t.Fatalf("attribute type = %T, want schema.StringAttribute", test.attribute)
+			}
+			if len(attribute.Validators) == 0 {
+				t.Fatal("attribute has no validators")
+			}
+
+			assertStringValidation(t, attribute.Validators, test.validValue, false)
+			assertStringValidation(t, attribute.Validators, test.badValue, true)
+		})
+	}
+
+	t.Run("DKIM key bits", func(t *testing.T) {
+		t.Parallel()
+
+		rawAttribute := domain_dkim_key.DomainDkimKeyResourceSchema().Attributes["bits"]
+		attribute, ok := rawAttribute.(rschema.Int64Attribute)
+		if !ok {
+			t.Fatalf("attribute type = %T, want schema.Int64Attribute", rawAttribute)
+		}
+		if len(attribute.Validators) == 0 {
+			t.Fatal("attribute has no validators")
+		}
+
+		assertInt64Validation(t, attribute.Validators, 1024, false)
+		assertInt64Validation(t, attribute.Validators, 2048, false)
+		assertInt64Validation(t, attribute.Validators, 4096, true)
+	})
+}
+
+func assertStringValidation(
+	t *testing.T,
+	validators []validator.String,
+	value string,
+	wantError bool,
+) {
+	t.Helper()
+
+	var response validator.StringResponse
+	request := validator.StringRequest{
+		Path:        path.Root("value"),
+		ConfigValue: types.StringValue(value),
+	}
+	for _, attributeValidator := range validators {
+		attributeValidator.ValidateString(context.Background(), request, &response)
+	}
+
+	if got := response.Diagnostics.HasError(); got != wantError {
+		t.Fatalf("validating %q: HasError() = %t, want %t; diagnostics: %v", value, got, wantError, response.Diagnostics)
+	}
+}
+
+func assertInt64Validation(
+	t *testing.T,
+	validators []validator.Int64,
+	value int64,
+	wantError bool,
+) {
+	t.Helper()
+
+	var response validator.Int64Response
+	request := validator.Int64Request{
+		Path:        path.Root("value"),
+		ConfigValue: types.Int64Value(value),
+	}
+	for _, attributeValidator := range validators {
+		attributeValidator.ValidateInt64(context.Background(), request, &response)
+	}
+
+	if got := response.Diagnostics.HasError(); got != wantError {
+		t.Fatalf("validating %d: HasError() = %t, want %t; diagnostics: %v", value, got, wantError, response.Diagnostics)
+	}
+}


### PR DESCRIPTION
## Summary

- add reusable Terraform Framework validators backed by Go's standard-library IP/CIDR and email parsers
- validate allowlist IP/CIDR values, dedicated IP addresses, DKIM key sizes, and mailing-list addresses during planning
- cover validator behavior, null/unknown handling, and all four resource-schema integrations with unit tests

## Why

These resource schemas previously accepted constrained values without plan-time validation. In particular, a typo in an IP allowlist address reached the Mailgun API and failed only during apply. The new validators return actionable Terraform diagnostics before any API request.

## Validation

- `go test -cover -timeout=120s -parallel=10 ./...`
- `go test -race ./internal/provider/schema_validators ./internal/provider/ip_allowlist ./internal/provider/domain_ip ./internal/provider/domain_dkim_key ./internal/provider/mailing_list_members`
- `go vet ./...`
- `golangci-lint run` (`0 issues`)
- `make generate`
- `git diff --check`

Closes #103

AI assistance disclosure: I used OpenAI Codex to inspect the provider, implement the validators, and run validation. I reviewed the final behavior, tests, and diff before submission.
