### PR TITLE
fix(404): stop treating transport errors as missing resources

### DIFF
--- a/.changelog/106.txt
+++ b/.changelog/106.txt
@@ -35,5 +35,13 @@ resource/mailgun_domain_sending_key: Read no longer treats a failed API-key list
 ```
 
 ```release-note:bug
-resource/mailgun_smtp_credential: Read no longer treats a failed credential listing (500, rate limit, transport error) the same as the credential being deleted. A listing failure during `terraform plan` now surfaces as a diagnostic with state left intact instead of silently dropping a live credential from state.
+resource/mailgun_smtp_credential: Read no longer treats a failed credential listing (500, rate limit, transport error) the same as the credential being deleted. A listing failure during `terraform plan` now surfaces as a diagnostic with state left intact instead of silently dropping a live credential from state. Separately, a genuine 404 from the domain-scoped listing (the parent domain was deleted out-of-band) now removes the resource from state instead of leaving `plan`/`apply` permanently stuck.
+```
+
+```release-note:bug
+resource/mailgun_domain_ip: Stop hard-erroring when the parent domain is deleted out-of-band. Read now removes the resource from state on a genuine 404 from the domain-scoped IP listing instead of leaving `plan`/`apply` permanently stuck.
+```
+
+```release-note:bug
+resource/mailgun_domain_dkim_key: Stop hard-erroring when the parent domain is deleted out-of-band. Read now removes the resource from state on a genuine 404 from the domain-scoped key listing instead of leaving `plan`/`apply` permanently stuck.
 ```

--- a/.changelog/106.txt
+++ b/.changelog/106.txt
@@ -1,0 +1,39 @@
+```release-note:bug
+resource/mailgun_domain: Stop hard-erroring when a domain is deleted out-of-band. Read now removes the resource from state on a genuine 404 (retried up to ~8s to absorb Mailgun's eventual consistency) instead of leaving `plan`/`apply` permanently stuck; a 429, 500, or transport error still surfaces as a diagnostic with state left intact.
+```
+
+```release-note:bug
+resource/mailgun_route: Stop hard-erroring when a route is deleted out-of-band. Read now removes the resource from state on a genuine 404 instead of leaving `plan`/`apply` permanently stuck.
+```
+
+```release-note:bug
+resource/mailgun_domain_tracking: Stop hard-erroring when the parent domain is deleted out-of-band. Read now removes the resource from state on a genuine 404 instead of leaving `plan`/`apply` permanently stuck.
+```
+
+```release-note:bug
+resource/mailgun_webhook: Read no longer mistakes a 500 (or any error whose message happens to contain "404" or "not found") for a missing webhook, which previously could drop a live resource from state. Detection is now a typed 404 check, plus one narrow check for the SDK's own no-URLs sentinel on an empty webhook.
+```
+
+```release-note:bug
+resource/mailgun_template: Read no longer mistakes a 500 (or any error whose message happens to contain "404" or "not found") for a missing template, which previously could drop a live resource from state. Detection is now a typed 404 check.
+```
+
+```release-note:bug
+resource/mailgun_template_version: Read no longer mistakes a 500 (or any error whose message happens to contain "404" or "not found") for a missing template version, which previously could drop a live resource from state. Detection is now a typed 404 check.
+```
+
+```release-note:bug
+resource/mailgun_mailing_list: Read no longer mistakes a 500 (or any error whose message happens to contain "404" or "not found") for a missing mailing list, which previously could drop a live resource from state. Detection is now a typed 404 check.
+```
+
+```release-note:bug
+resource/mailgun_mailing_list_member: Read no longer mistakes a 500 (or any error whose message happens to contain "404" or "not found") for a missing member, which previously could drop a live resource from state. Detection is now a typed 404 check.
+```
+
+```release-note:bug
+resource/mailgun_domain_sending_key: Read no longer treats a failed API-key listing (500, rate limit, transport error) the same as the key being deleted. A listing failure during `terraform plan` now surfaces as a diagnostic with state left intact instead of silently dropping a live key from state.
+```
+
+```release-note:bug
+resource/mailgun_smtp_credential: Read no longer treats a failed credential listing (500, rate limit, transport error) the same as the credential being deleted. A listing failure during `terraform plan` now surfaces as a diagnostic with state left intact instead of silently dropping a live credential from state.
+```

--- a/internal/provider/domain_dkim_key/resource.go
+++ b/internal/provider/domain_dkim_key/resource.go
@@ -14,6 +14,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mailgun/mailgun-go/v5"
 	"github.com/mailgun/mailgun-go/v5/mtypes"
+
+	"github.com/hackthebox/terraform-provider-mailgun/internal/provider/mgerr"
 )
 
 var (
@@ -137,6 +139,10 @@ func (r *domainDkimKeyResource) Read(ctx context.Context, req resource.ReadReque
 	// List domain keys and find ours
 	domainKey, found, err := r.findDomainKey(readCtx, domain, selector)
 	if err != nil {
+		if mgerr.IsNotFound(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Reading Domain DKIM Key",
 			fmt.Sprintf("Could not read DKIM key for domain %s with selector %s: %s", domain, selector, err.Error()),

--- a/internal/provider/domain_dkim_key/resource_read_internal_test.go
+++ b/internal/provider/domain_dkim_key/resource_read_internal_test.go
@@ -1,0 +1,121 @@
+// Copyright Hack The Box 2025, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package domain_dkim_key
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/mailgun/mailgun-go/v5"
+)
+
+func testClient(t *testing.T, handler http.HandlerFunc) *mailgun.Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	mg := mailgun.NewMailgun("test-key")
+	if err := mg.SetAPIBase(srv.URL); err != nil {
+		t.Fatalf("SetAPIBase: %v", err)
+	}
+	return mg
+}
+
+func dkimKeyStateObject(t *testing.T, overrides map[string]tftypes.Value) tftypes.Value {
+	t.Helper()
+
+	objType, ok := DomainDkimKeyResourceSchema().Type().TerraformType(context.Background()).(tftypes.Object)
+	if !ok {
+		t.Fatal("schema terraform type is not an object")
+	}
+
+	attrs := make(map[string]tftypes.Value, len(objType.AttributeTypes))
+	for name, attrType := range objType.AttributeTypes {
+		if override, found := overrides[name]; found {
+			attrs[name] = override
+			continue
+		}
+		attrs[name] = tftypes.NewValue(attrType, nil)
+	}
+
+	return tftypes.NewValue(objType, attrs)
+}
+
+func readDkimKey(t *testing.T, client *mailgun.Client, domain, selector string) *resource.ReadResponse {
+	t.Helper()
+
+	resourceSchema := DomainDkimKeyResourceSchema()
+	state := tfsdk.State{
+		Raw: dkimKeyStateObject(t, map[string]tftypes.Value{
+			"domain":   tftypes.NewValue(tftypes.String, domain),
+			"selector": tftypes.NewValue(tftypes.String, selector),
+		}),
+		Schema: resourceSchema,
+	}
+
+	resp := &resource.ReadResponse{State: state}
+	(&domainDkimKeyResource{client: client}).Read(context.Background(), resource.ReadRequest{State: state}, resp)
+	return resp
+}
+
+// A genuine 404 from the domain-scoped key listing means the parent domain
+// was deleted out of band, not that the listing merely failed; Read must
+// recover the same way it does for a selector that is simply no longer present.
+func TestRead_RemovesResourceOnGenuine404(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Domain not found"}`))
+	})
+
+	resp := readDkimKey(t, client, "gone.example.com", "selector1")
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+	if !resp.State.Raw.IsNull() {
+		t.Error("expected the resource to be removed from state on a genuine 404")
+	}
+}
+
+// A listing failure (500, rate limit, transport error) is not the same as
+// the domain being gone: it must produce a diagnostic and leave state
+// intact rather than silently dropping a live resource.
+func TestRead_ListFailureProducesErrorAndLeavesStateIntact(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"boom"}`))
+	})
+
+	resp := readDkimKey(t, client, "example.com", "selector1")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic when the DKIM key listing fails")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a listing failure must not remove the resource from state")
+	}
+}
+
+func TestRead_TransportErrorProducesErrorAndLeavesStateIntact(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	mg := mailgun.NewMailgun("test-key")
+	if err := mg.SetAPIBase(srv.URL); err != nil {
+		t.Fatalf("SetAPIBase: %v", err)
+	}
+	srv.Close() // connections to this address now fail outright
+
+	resp := readDkimKey(t, mg, "example.com", "selector1")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a transport failure")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a transport failure must not remove the resource from state")
+	}
+}

--- a/internal/provider/domain_ip/resource.go
+++ b/internal/provider/domain_ip/resource.go
@@ -12,6 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mailgun/mailgun-go/v5"
+
+	"github.com/hackthebox/terraform-provider-mailgun/internal/provider/mgerr"
 )
 
 var (
@@ -103,6 +105,10 @@ func (r *domainIPResource) Read(ctx context.Context, req resource.ReadRequest, r
 	// List domain IPs and check if our IP exists
 	ips, err := r.client.ListDomainIPs(readCtx, domain)
 	if err != nil {
+		if mgerr.IsNotFound(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Reading Domain IPs",
 			fmt.Sprintf("Could not read IPs for domain %s: %s", domain, err.Error()),

--- a/internal/provider/domain_ip/resource_read_internal_test.go
+++ b/internal/provider/domain_ip/resource_read_internal_test.go
@@ -1,0 +1,123 @@
+// Copyright Hack The Box 2025, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package domain_ip
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/mailgun/mailgun-go/v5"
+)
+
+func testClient(t *testing.T, handler http.HandlerFunc) *mailgun.Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	mg := mailgun.NewMailgun("test-key")
+	if err := mg.SetAPIBase(srv.URL); err != nil {
+		t.Fatalf("SetAPIBase: %v", err)
+	}
+	return mg
+}
+
+// domainIPStateObject builds a resource-shaped tftypes.Value, defaulting
+// every attribute to null and applying the given overrides.
+func domainIPStateObject(t *testing.T, overrides map[string]tftypes.Value) tftypes.Value {
+	t.Helper()
+
+	objType, ok := DomainIPResourceSchema().Type().TerraformType(context.Background()).(tftypes.Object)
+	if !ok {
+		t.Fatal("schema terraform type is not an object")
+	}
+
+	attrs := make(map[string]tftypes.Value, len(objType.AttributeTypes))
+	for name, attrType := range objType.AttributeTypes {
+		if override, found := overrides[name]; found {
+			attrs[name] = override
+			continue
+		}
+		attrs[name] = tftypes.NewValue(attrType, nil)
+	}
+
+	return tftypes.NewValue(objType, attrs)
+}
+
+func readDomainIP(t *testing.T, client *mailgun.Client, domain, ip string) *resource.ReadResponse {
+	t.Helper()
+
+	resourceSchema := DomainIPResourceSchema()
+	state := tfsdk.State{
+		Raw: domainIPStateObject(t, map[string]tftypes.Value{
+			"domain": tftypes.NewValue(tftypes.String, domain),
+			"ip":     tftypes.NewValue(tftypes.String, ip),
+		}),
+		Schema: resourceSchema,
+	}
+
+	resp := &resource.ReadResponse{State: state}
+	(&domainIPResource{client: client}).Read(context.Background(), resource.ReadRequest{State: state}, resp)
+	return resp
+}
+
+// A genuine 404 from the domain-scoped IP listing means the parent domain
+// was deleted out of band, not that the listing merely failed; Read must
+// recover the same way it does for an IP that is simply no longer assigned.
+func TestRead_RemovesResourceOnGenuine404(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Domain not found"}`))
+	})
+
+	resp := readDomainIP(t, client, "gone.example.com", "10.0.0.1")
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+	if !resp.State.Raw.IsNull() {
+		t.Error("expected the resource to be removed from state on a genuine 404")
+	}
+}
+
+// A listing failure (500, rate limit, transport error) is not the same as
+// the domain being gone: it must produce a diagnostic and leave state
+// intact rather than silently dropping a live resource.
+func TestRead_ListFailureProducesErrorAndLeavesStateIntact(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"boom"}`))
+	})
+
+	resp := readDomainIP(t, client, "example.com", "10.0.0.1")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic when the IP listing fails")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a listing failure must not remove the resource from state")
+	}
+}
+
+func TestRead_TransportErrorProducesErrorAndLeavesStateIntact(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	mg := mailgun.NewMailgun("test-key")
+	if err := mg.SetAPIBase(srv.URL); err != nil {
+		t.Fatalf("SetAPIBase: %v", err)
+	}
+	srv.Close() // connections to this address now fail outright
+
+	resp := readDomainIP(t, mg, "example.com", "10.0.0.1")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a transport failure")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a transport failure must not remove the resource from state")
+	}
+}

--- a/internal/provider/domain_sending_keys/resource.go
+++ b/internal/provider/domain_sending_keys/resource.go
@@ -121,9 +121,15 @@ func (r *domainSendingKeyResource) Read(ctx context.Context, req resource.ReadRe
 	readCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	apiKey, err := r.findKey(readCtx, keyID, domain)
+	apiKey, found, err := r.findKey(readCtx, keyID, domain)
 	if err != nil {
-		// Key not found - remove from state
+		resp.Diagnostics.AddError(
+			"Error Reading Domain Sending Key",
+			fmt.Sprintf("Could not read sending key %s: %s", keyID, err.Error()),
+		)
+		return
+	}
+	if !found {
 		resp.State.RemoveResource(ctx)
 		return
 	}
@@ -233,8 +239,11 @@ func (r *domainSendingKeyResource) ImportState(ctx context.Context, req resource
 	)
 }
 
-// findKey searches for a domain sending key by ID
-func (r *domainSendingKeyResource) findKey(ctx context.Context, keyID, domain string) (*mtypes.APIKey, error) {
+// findKey searches for a domain sending key by ID. The bool return
+// distinguishes "not present" from a listing failure, so Read can tell a
+// genuine miss from a transport/API error instead of treating both as
+// deleted.
+func (r *domainSendingKeyResource) findKey(ctx context.Context, keyID, domain string) (*mtypes.APIKey, bool, error) {
 	opts := &mailgun.ListAPIKeysOptions{
 		DomainName: domain,
 		Kind:       "domain",
@@ -242,16 +251,16 @@ func (r *domainSendingKeyResource) findKey(ctx context.Context, keyID, domain st
 
 	keys, err := r.client.ListAPIKeys(ctx, opts)
 	if err != nil {
-		return nil, fmt.Errorf("error listing API keys: %w", err)
+		return nil, false, fmt.Errorf("error listing API keys: %w", err)
 	}
 
 	for _, key := range keys {
 		if key.ID == keyID {
-			return &key, nil
+			return &key, true, nil
 		}
 	}
 
-	return nil, fmt.Errorf("sending key not found")
+	return nil, false, nil
 }
 
 // findKeyByID searches for a domain sending key by ID across all domains

--- a/internal/provider/domain_sending_keys/resource_read_internal_test.go
+++ b/internal/provider/domain_sending_keys/resource_read_internal_test.go
@@ -1,0 +1,177 @@
+// Copyright Hack The Box 2025, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package domain_sending_keys
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/mailgun/mailgun-go/v5"
+)
+
+func testClient(t *testing.T, handler http.HandlerFunc) *mailgun.Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	mg := mailgun.NewMailgun("test-key")
+	if err := mg.SetAPIBase(srv.URL); err != nil {
+		t.Fatalf("SetAPIBase: %v", err)
+	}
+	return mg
+}
+
+func TestFindKey_ReturnsFoundTrueWhenPresent(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"items":[{"id":"key-1","kind":"domain","domain_name":"example.com"}]}`))
+	})
+
+	r := &domainSendingKeyResource{client: client}
+	key, found, err := r.findKey(context.Background(), "key-1", "example.com")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected the key to be found")
+	}
+	if key.ID != "key-1" {
+		t.Errorf("key.ID = %q, want %q", key.ID, "key-1")
+	}
+}
+
+func TestFindKey_ReturnsFoundFalseWhenAbsent(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"items":[]}`))
+	})
+
+	r := &domainSendingKeyResource{client: client}
+	_, found, err := r.findKey(context.Background(), "gone-key", "example.com")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found {
+		t.Error("expected the key not to be found")
+	}
+}
+
+func TestFindKey_ReturnsErrorOnListFailure(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"boom"}`))
+	})
+
+	r := &domainSendingKeyResource{client: client}
+	_, found, err := r.findKey(context.Background(), "key-1", "example.com")
+
+	if err == nil {
+		t.Fatal("expected an error when the listing itself fails")
+	}
+	if found {
+		t.Error("found must be false when err is non-nil")
+	}
+}
+
+// readStateObject builds a resource-shaped tftypes.Value, defaulting every
+// attribute to null and applying the given overrides.
+func readStateObject(t *testing.T, overrides map[string]tftypes.Value) tftypes.Value {
+	t.Helper()
+
+	objType, ok := DomainSendingKeyResourceSchema().Type().TerraformType(context.Background()).(tftypes.Object)
+	if !ok {
+		t.Fatal("schema terraform type is not an object")
+	}
+
+	attrs := make(map[string]tftypes.Value, len(objType.AttributeTypes))
+	for name, attrType := range objType.AttributeTypes {
+		if override, found := overrides[name]; found {
+			attrs[name] = override
+			continue
+		}
+		attrs[name] = tftypes.NewValue(attrType, nil)
+	}
+
+	return tftypes.NewValue(objType, attrs)
+}
+
+func readSendingKey(t *testing.T, client *mailgun.Client, id, domain string) *resource.ReadResponse {
+	t.Helper()
+
+	resourceSchema := DomainSendingKeyResourceSchema()
+	state := tfsdk.State{
+		Raw: readStateObject(t, map[string]tftypes.Value{
+			"id":     tftypes.NewValue(tftypes.String, id),
+			"domain": tftypes.NewValue(tftypes.String, domain),
+		}),
+		Schema: resourceSchema,
+	}
+
+	resp := &resource.ReadResponse{State: state}
+	(&domainSendingKeyResource{client: client}).Read(context.Background(), resource.ReadRequest{State: state}, resp)
+	return resp
+}
+
+func TestRead_RemovesResourceWhenKeyAbsent(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"items":[]}`))
+	})
+
+	resp := readSendingKey(t, client, "gone-key", "example.com")
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+	if !resp.State.Raw.IsNull() {
+		t.Error("expected the resource to be removed from state when the key is absent")
+	}
+}
+
+// A listing failure (500, rate limit, transport error) is not the same as the
+// key being gone: it must produce a diagnostic and leave state intact rather
+// than silently dropping a live resource.
+func TestRead_ListFailureProducesErrorAndLeavesStateIntact(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"boom"}`))
+	})
+
+	resp := readSendingKey(t, client, "key-1", "example.com")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic when the API key listing fails")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a listing failure must not remove the resource from state")
+	}
+}
+
+func TestRead_TransportErrorProducesErrorAndLeavesStateIntact(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	mg := mailgun.NewMailgun("test-key")
+	if err := mg.SetAPIBase(srv.URL); err != nil {
+		t.Fatalf("SetAPIBase: %v", err)
+	}
+	srv.Close() // connections to this address now fail outright
+
+	resp := readSendingKey(t, mg, "key-1", "example.com")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a transport failure")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a transport failure must not remove the resource from state")
+	}
+}

--- a/internal/provider/domain_sending_keys/resource_read_internal_test.go
+++ b/internal/provider/domain_sending_keys/resource_read_internal_test.go
@@ -81,6 +81,11 @@ func TestFindKey_ReturnsErrorOnListFailure(t *testing.T) {
 	if found {
 		t.Error("found must be false when err is non-nil")
 	}
+	// The wire status must survive the wrap (%w, not %v), or mgerr.IsNotFound
+	// and callers using errors.As/Is lose the ability to inspect the cause.
+	if got := mailgun.GetStatusFromErr(err); got != http.StatusInternalServerError {
+		t.Errorf("GetStatusFromErr(err) = %d, want %d (the wire status must survive the wrap)", got, http.StatusInternalServerError)
+	}
 }
 
 // readStateObject builds a resource-shaped tftypes.Value, defaulting every

--- a/internal/provider/domain_tracking/resource.go
+++ b/internal/provider/domain_tracking/resource.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hackthebox/terraform-provider-mailgun/internal/provider/mgerr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mailgun/mailgun-go/v5"
@@ -101,6 +102,10 @@ func (r *domainTrackingResource) Read(ctx context.Context, req resource.ReadRequ
 	domain := state.Domain.ValueString()
 
 	if err := r.readTrackingSettings(ctx, domain, &state); err != nil {
+		if mgerr.IsNotFound(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Reading Domain Tracking",
 			fmt.Sprintf("Could not read tracking settings for domain %s: %s", domain, err.Error()),

--- a/internal/provider/domain_tracking/resource_read_internal_test.go
+++ b/internal/provider/domain_tracking/resource_read_internal_test.go
@@ -1,0 +1,130 @@
+// Copyright Hack The Box 2025, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package domain_tracking
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/mailgun/mailgun-go/v5"
+)
+
+func testClient(t *testing.T, handler http.HandlerFunc) *mailgun.Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	mg := mailgun.NewMailgun("test-key")
+	if err := mg.SetAPIBase(srv.URL); err != nil {
+		t.Fatalf("SetAPIBase: %v", err)
+	}
+	return mg
+}
+
+// trackingStateObject builds a resource-shaped tftypes.Value, defaulting
+// every attribute to null and applying the given overrides.
+func trackingStateObject(t *testing.T, overrides map[string]tftypes.Value) tftypes.Value {
+	t.Helper()
+
+	objType, ok := DomainTrackingResourceSchema().Type().TerraformType(context.Background()).(tftypes.Object)
+	if !ok {
+		t.Fatal("schema terraform type is not an object")
+	}
+
+	attrs := make(map[string]tftypes.Value, len(objType.AttributeTypes))
+	for name, attrType := range objType.AttributeTypes {
+		if override, found := overrides[name]; found {
+			attrs[name] = override
+			continue
+		}
+		attrs[name] = tftypes.NewValue(attrType, nil)
+	}
+
+	return tftypes.NewValue(objType, attrs)
+}
+
+func readDomainTracking(t *testing.T, client *mailgun.Client, domain string) *resource.ReadResponse {
+	t.Helper()
+
+	resourceSchema := DomainTrackingResourceSchema()
+	state := tfsdk.State{
+		Raw:    trackingStateObject(t, map[string]tftypes.Value{"domain": tftypes.NewValue(tftypes.String, domain)}),
+		Schema: resourceSchema,
+	}
+
+	resp := &resource.ReadResponse{State: state}
+	(&domainTrackingResource{client: client}).Read(context.Background(), resource.ReadRequest{State: state}, resp)
+	return resp
+}
+
+func TestRead_RemovesResourceOnGenuine404(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Domain not found"}`))
+	})
+
+	resp := readDomainTracking(t, client, "gone.example.com")
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+	if !resp.State.Raw.IsNull() {
+		t.Error("expected the resource to be removed from state on a genuine 404")
+	}
+}
+
+func TestRead_500ProducesErrorAndLeavesStateIntact(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"boom"}`))
+	})
+
+	resp := readDomainTracking(t, client, "test.example.com")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a 500 response")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a server error must not remove the resource from state")
+	}
+}
+
+func TestRead_RateLimitedProducesErrorAndLeavesStateIntact(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"message":"Too Many Requests"}`))
+	})
+
+	resp := readDomainTracking(t, client, "test.example.com")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a 429 response")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a rate-limited error must not remove the resource from state")
+	}
+}
+
+func TestRead_TransportErrorProducesErrorAndLeavesStateIntact(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	mg := mailgun.NewMailgun("test-key")
+	if err := mg.SetAPIBase(srv.URL); err != nil {
+		t.Fatalf("SetAPIBase: %v", err)
+	}
+	srv.Close() // connections to this address now fail outright
+
+	resp := readDomainTracking(t, mg, "test.example.com")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a transport failure")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a transport failure must not remove the resource from state")
+	}
+}

--- a/internal/provider/domains/resource.go
+++ b/internal/provider/domains/resource.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hackthebox/terraform-provider-mailgun/internal/provider/mgerr"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -250,6 +251,10 @@ func (r *DomainResource) Read(ctx context.Context, req resource.ReadRequest, res
 	// Get the domain via Mailgun API
 	domainResp, err := getDomainWithRetry(readCtx, r.client, domainName, domainReadMaxAttempts, domainReadRetryDelay)
 	if err != nil {
+		if mgerr.IsNotFound(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Reading Domain",
 			fmt.Sprintf("Could not read domain %s: %s", domainName, err),

--- a/internal/provider/domains/resource_read_internal_test.go
+++ b/internal/provider/domains/resource_read_internal_test.go
@@ -1,0 +1,118 @@
+// Copyright Hack The Box 2025, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package domains
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/mailgun/mailgun-go/v5"
+)
+
+// domainStateObject builds a resource-shaped tftypes.Value, defaulting every
+// attribute to null and applying the given overrides.
+func domainStateObject(t *testing.T, overrides map[string]tftypes.Value) tftypes.Value {
+	t.Helper()
+
+	objType, ok := DomainResourceSchema().Type().TerraformType(context.Background()).(tftypes.Object)
+	if !ok {
+		t.Fatal("schema terraform type is not an object")
+	}
+
+	attrs := make(map[string]tftypes.Value, len(objType.AttributeTypes))
+	for name, attrType := range objType.AttributeTypes {
+		if override, found := overrides[name]; found {
+			attrs[name] = override
+			continue
+		}
+		attrs[name] = tftypes.NewValue(attrType, nil)
+	}
+
+	return tftypes.NewValue(objType, attrs)
+}
+
+func readDomain(t *testing.T, client *mailgun.Client, name string) *resource.ReadResponse {
+	t.Helper()
+
+	resourceSchema := DomainResourceSchema()
+	state := tfsdk.State{
+		Raw:    domainStateObject(t, map[string]tftypes.Value{"name": tftypes.NewValue(tftypes.String, name)}),
+		Schema: resourceSchema,
+	}
+
+	resp := &resource.ReadResponse{State: state}
+	(&DomainResource{client: client}).Read(context.Background(), resource.ReadRequest{State: state}, resp)
+	return resp
+}
+
+func TestRead_RemovesResourceOnGenuine404(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Domain not found"}`))
+	})
+
+	resp := readDomain(t, client, "gone.example.com")
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+	if !resp.State.Raw.IsNull() {
+		t.Error("expected the resource to be removed from state on a genuine 404")
+	}
+}
+
+func TestRead_500ProducesErrorAndLeavesStateIntact(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"boom"}`))
+	})
+
+	resp := readDomain(t, client, "test.example.com")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a 500 response")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a transport/server error must not remove the resource from state")
+	}
+}
+
+func TestRead_RateLimitedProducesErrorAndLeavesStateIntact(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"message":"Too Many Requests"}`))
+	})
+
+	resp := readDomain(t, client, "test.example.com")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a 429 response")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a rate-limited error must not remove the resource from state")
+	}
+}
+
+func TestRead_TransportErrorProducesErrorAndLeavesStateIntact(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	mg := mailgun.NewMailgun("test-key")
+	if err := mg.SetAPIBase(srv.URL); err != nil {
+		t.Fatalf("SetAPIBase: %v", err)
+	}
+	srv.Close() // connections to this address now fail outright
+
+	resp := readDomain(t, mg, "test.example.com")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a transport failure")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a transport failure must not remove the resource from state")
+	}
+}

--- a/internal/provider/mailing_list_members/resource.go
+++ b/internal/provider/mailing_list_members/resource.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hackthebox/terraform-provider-mailgun/internal/provider/mgerr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mailgun/mailgun-go/v5"
@@ -139,8 +140,7 @@ func (r *mailingListMemberResource) Read(ctx context.Context, req resource.ReadR
 
 	member, err := r.client.GetMember(readCtx, memberAddress, listAddress)
 	if err != nil {
-		// Check if member doesn't exist
-		if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "404") {
+		if mgerr.IsNotFound(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/provider/mailing_list_members/resource_read_internal_test.go
+++ b/internal/provider/mailing_list_members/resource_read_internal_test.go
@@ -1,0 +1,151 @@
+// Copyright Hack The Box 2025, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package mailing_list_members
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/mailgun/mailgun-go/v5"
+)
+
+func testClient(t *testing.T, handler http.HandlerFunc) *mailgun.Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	mg := mailgun.NewMailgun("test-key")
+	if err := mg.SetAPIBase(srv.URL); err != nil {
+		t.Fatalf("SetAPIBase: %v", err)
+	}
+	return mg
+}
+
+// memberStateObject builds a resource-shaped tftypes.Value, defaulting every
+// attribute to null and applying the given overrides.
+func memberStateObject(t *testing.T, overrides map[string]tftypes.Value) tftypes.Value {
+	t.Helper()
+
+	objType, ok := MailingListMemberResourceSchema().Type().TerraformType(context.Background()).(tftypes.Object)
+	if !ok {
+		t.Fatal("schema terraform type is not an object")
+	}
+
+	attrs := make(map[string]tftypes.Value, len(objType.AttributeTypes))
+	for name, attrType := range objType.AttributeTypes {
+		if override, found := overrides[name]; found {
+			attrs[name] = override
+			continue
+		}
+		attrs[name] = tftypes.NewValue(attrType, nil)
+	}
+
+	return tftypes.NewValue(objType, attrs)
+}
+
+func readMember(t *testing.T, client *mailgun.Client, memberAddress string) *resource.ReadResponse {
+	t.Helper()
+
+	resourceSchema := MailingListMemberResourceSchema()
+	state := tfsdk.State{
+		Raw: memberStateObject(t, map[string]tftypes.Value{
+			"list_address":   tftypes.NewValue(tftypes.String, "list@example.com"),
+			"member_address": tftypes.NewValue(tftypes.String, memberAddress),
+		}),
+		Schema: resourceSchema,
+	}
+
+	resp := &resource.ReadResponse{State: state}
+	(&mailingListMemberResource{client: client}).Read(context.Background(), resource.ReadRequest{State: state}, resp)
+	return resp
+}
+
+func TestRead_RemovesResourceOnGenuine404(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Member not found"}`))
+	})
+
+	resp := readMember(t, client, "gone@example.com")
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+	if !resp.State.Raw.IsNull() {
+		t.Error("expected the resource to be removed from state on a genuine 404")
+	}
+}
+
+// A 500 whose body happens to mention "not found" must not be mistaken for a
+// 404: the string-matching this replaces would remove a live resource here.
+func TestRead_500MentioningNotFoundIsNotTreatedAsMissing(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"upstream dependency not found: 404 from internal service"}`))
+	})
+
+	resp := readMember(t, client, "member@example.com")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a 500 response, even one mentioning 'not found'")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a 500 must not remove the resource from state just because its body mentions 'not found'")
+	}
+}
+
+func TestRead_500ProducesErrorAndLeavesStateIntact(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"boom"}`))
+	})
+
+	resp := readMember(t, client, "member@example.com")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a 500 response")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a server error must not remove the resource from state")
+	}
+}
+
+func TestRead_RateLimitedProducesErrorAndLeavesStateIntact(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"message":"Too Many Requests"}`))
+	})
+
+	resp := readMember(t, client, "member@example.com")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a 429 response")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a rate-limited error must not remove the resource from state")
+	}
+}
+
+func TestRead_TransportErrorProducesErrorAndLeavesStateIntact(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	mg := mailgun.NewMailgun("test-key")
+	if err := mg.SetAPIBase(srv.URL); err != nil {
+		t.Fatalf("SetAPIBase: %v", err)
+	}
+	srv.Close() // connections to this address now fail outright
+
+	resp := readMember(t, mg, "member@example.com")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a transport failure")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a transport failure must not remove the resource from state")
+	}
+}

--- a/internal/provider/mailing_lists/resource.go
+++ b/internal/provider/mailing_lists/resource.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hackthebox/terraform-provider-mailgun/internal/provider/mgerr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mailgun/mailgun-go/v5"
@@ -132,8 +133,7 @@ func (r *mailingListResource) Read(ctx context.Context, req resource.ReadRequest
 
 	list, err := r.client.GetMailingList(readCtx, address)
 	if err != nil {
-		// Check if list doesn't exist
-		if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "404") {
+		if mgerr.IsNotFound(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/provider/mailing_lists/resource_read_internal_test.go
+++ b/internal/provider/mailing_lists/resource_read_internal_test.go
@@ -1,0 +1,148 @@
+// Copyright Hack The Box 2025, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package mailing_lists
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/mailgun/mailgun-go/v5"
+)
+
+func testClient(t *testing.T, handler http.HandlerFunc) *mailgun.Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	mg := mailgun.NewMailgun("test-key")
+	if err := mg.SetAPIBase(srv.URL); err != nil {
+		t.Fatalf("SetAPIBase: %v", err)
+	}
+	return mg
+}
+
+// mailingListStateObject builds a resource-shaped tftypes.Value, defaulting
+// every attribute to null and applying the given overrides.
+func mailingListStateObject(t *testing.T, overrides map[string]tftypes.Value) tftypes.Value {
+	t.Helper()
+
+	objType, ok := MailingListResourceSchema().Type().TerraformType(context.Background()).(tftypes.Object)
+	if !ok {
+		t.Fatal("schema terraform type is not an object")
+	}
+
+	attrs := make(map[string]tftypes.Value, len(objType.AttributeTypes))
+	for name, attrType := range objType.AttributeTypes {
+		if override, found := overrides[name]; found {
+			attrs[name] = override
+			continue
+		}
+		attrs[name] = tftypes.NewValue(attrType, nil)
+	}
+
+	return tftypes.NewValue(objType, attrs)
+}
+
+func readMailingList(t *testing.T, client *mailgun.Client, address string) *resource.ReadResponse {
+	t.Helper()
+
+	resourceSchema := MailingListResourceSchema()
+	state := tfsdk.State{
+		Raw:    mailingListStateObject(t, map[string]tftypes.Value{"address": tftypes.NewValue(tftypes.String, address)}),
+		Schema: resourceSchema,
+	}
+
+	resp := &resource.ReadResponse{State: state}
+	(&mailingListResource{client: client}).Read(context.Background(), resource.ReadRequest{State: state}, resp)
+	return resp
+}
+
+func TestRead_RemovesResourceOnGenuine404(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Mailing list not found"}`))
+	})
+
+	resp := readMailingList(t, client, "gone@example.com")
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+	if !resp.State.Raw.IsNull() {
+		t.Error("expected the resource to be removed from state on a genuine 404")
+	}
+}
+
+// A 500 whose body happens to mention "not found" must not be mistaken for a
+// 404: the string-matching this replaces would remove a live resource here.
+func TestRead_500MentioningNotFoundIsNotTreatedAsMissing(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"upstream dependency not found: 404 from internal service"}`))
+	})
+
+	resp := readMailingList(t, client, "list@example.com")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a 500 response, even one mentioning 'not found'")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a 500 must not remove the resource from state just because its body mentions 'not found'")
+	}
+}
+
+func TestRead_500ProducesErrorAndLeavesStateIntact(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"boom"}`))
+	})
+
+	resp := readMailingList(t, client, "list@example.com")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a 500 response")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a server error must not remove the resource from state")
+	}
+}
+
+func TestRead_RateLimitedProducesErrorAndLeavesStateIntact(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"message":"Too Many Requests"}`))
+	})
+
+	resp := readMailingList(t, client, "list@example.com")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a 429 response")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a rate-limited error must not remove the resource from state")
+	}
+}
+
+func TestRead_TransportErrorProducesErrorAndLeavesStateIntact(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	mg := mailgun.NewMailgun("test-key")
+	if err := mg.SetAPIBase(srv.URL); err != nil {
+		t.Fatalf("SetAPIBase: %v", err)
+	}
+	srv.Close() // connections to this address now fail outright
+
+	resp := readMailingList(t, mg, "list@example.com")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a transport failure")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a transport failure must not remove the resource from state")
+	}
+}

--- a/internal/provider/mgerr/mgerr.go
+++ b/internal/provider/mgerr/mgerr.go
@@ -1,0 +1,24 @@
+// Copyright Hack The Box 2025, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+// Package mgerr gives every resource one typed way to ask "was that a 404?"
+package mgerr
+
+import (
+	"net/http"
+
+	"github.com/mailgun/mailgun-go/v5"
+)
+
+// IsNotFound reports whether err represents an HTTP 404 response from
+// Mailgun. It resolves through wrapped errors the same way
+// mailgun.GetStatusFromErr does (errors.As against *mailgun.UnexpectedResponseError),
+// so a %w-wrapped error or one nested inside *mailgun.RateLimitedError still
+// matches. Transport failures and other status codes report -1 from the SDK
+// and so are never mistaken for a 404.
+func IsNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	return mailgun.GetStatusFromErr(err) == http.StatusNotFound
+}

--- a/internal/provider/mgerr/mgerr.go
+++ b/internal/provider/mgerr/mgerr.go
@@ -14,11 +14,8 @@ import (
 // Mailgun. It resolves through wrapped errors the same way
 // mailgun.GetStatusFromErr does (errors.As against *mailgun.UnexpectedResponseError),
 // so a %w-wrapped error or one nested inside *mailgun.RateLimitedError still
-// matches. Transport failures and other status codes report -1 from the SDK
-// and so are never mistaken for a 404.
+// matches. Transport failures, other status codes and a nil error all report
+// -1 from the SDK and so are never mistaken for a 404.
 func IsNotFound(err error) bool {
-	if err == nil {
-		return false
-	}
 	return mailgun.GetStatusFromErr(err) == http.StatusNotFound
 }

--- a/internal/provider/mgerr/mgerr_test.go
+++ b/internal/provider/mgerr/mgerr_test.go
@@ -1,0 +1,65 @@
+// Copyright Hack The Box 2025, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package mgerr
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/mailgun/mailgun-go/v5"
+)
+
+func TestIsNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "404 UnexpectedResponseError",
+			err:  &mailgun.UnexpectedResponseError{Actual: 404},
+			want: true,
+		},
+		{
+			name: "404 wrapped via %w",
+			err:  fmt.Errorf("reading domain: %w", &mailgun.UnexpectedResponseError{Actual: 404}),
+			want: true,
+		},
+		{
+			name: "429 RateLimitedError",
+			err:  &mailgun.RateLimitedError{Err: &mailgun.UnexpectedResponseError{Actual: 429}},
+			want: false,
+		},
+		{
+			name: "500",
+			err:  &mailgun.UnexpectedResponseError{Actual: 500},
+			want: false,
+		},
+		{
+			name: "transport failure",
+			err:  &url.Error{Op: "Get", URL: "https://api.mailgun.net/v3/domains/example.com", Err: errors.New("connection refused")},
+			want: false,
+		},
+		{
+			name: "bare error mentioning not found",
+			err:  errors.New("not found"),
+			want: false,
+		},
+		{
+			name: "nil",
+			err:  nil,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsNotFound(tt.err); got != tt.want {
+				t.Errorf("IsNotFound(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/provider/routes/resource.go
+++ b/internal/provider/routes/resource.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hackthebox/terraform-provider-mailgun/internal/provider/mgerr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mailgun/mailgun-go/v5"
@@ -112,6 +113,10 @@ func (r *routeResource) Read(ctx context.Context, req resource.ReadRequest, resp
 
 	route, err := r.client.GetRoute(readCtx, state.Id.ValueString())
 	if err != nil {
+		if mgerr.IsNotFound(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Reading Mailgun Route",
 			fmt.Sprintf("Could not read route %s: %s", state.Id.ValueString(), err.Error()),

--- a/internal/provider/routes/resource_read_internal_test.go
+++ b/internal/provider/routes/resource_read_internal_test.go
@@ -1,0 +1,130 @@
+// Copyright Hack The Box 2025, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package routes
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/mailgun/mailgun-go/v5"
+)
+
+func testClient(t *testing.T, handler http.HandlerFunc) *mailgun.Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	mg := mailgun.NewMailgun("test-key")
+	if err := mg.SetAPIBase(srv.URL); err != nil {
+		t.Fatalf("SetAPIBase: %v", err)
+	}
+	return mg
+}
+
+// routeStateObject builds a resource-shaped tftypes.Value, defaulting every
+// attribute to null and applying the given overrides.
+func routeStateObject(t *testing.T, overrides map[string]tftypes.Value) tftypes.Value {
+	t.Helper()
+
+	objType, ok := RouteResourceSchema().Type().TerraformType(context.Background()).(tftypes.Object)
+	if !ok {
+		t.Fatal("schema terraform type is not an object")
+	}
+
+	attrs := make(map[string]tftypes.Value, len(objType.AttributeTypes))
+	for name, attrType := range objType.AttributeTypes {
+		if override, found := overrides[name]; found {
+			attrs[name] = override
+			continue
+		}
+		attrs[name] = tftypes.NewValue(attrType, nil)
+	}
+
+	return tftypes.NewValue(objType, attrs)
+}
+
+func readRoute(t *testing.T, client *mailgun.Client, id string) *resource.ReadResponse {
+	t.Helper()
+
+	resourceSchema := RouteResourceSchema()
+	state := tfsdk.State{
+		Raw:    routeStateObject(t, map[string]tftypes.Value{"id": tftypes.NewValue(tftypes.String, id)}),
+		Schema: resourceSchema,
+	}
+
+	resp := &resource.ReadResponse{State: state}
+	(&routeResource{client: client}).Read(context.Background(), resource.ReadRequest{State: state}, resp)
+	return resp
+}
+
+func TestRead_RemovesResourceOnGenuine404(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Route not found"}`))
+	})
+
+	resp := readRoute(t, client, "gone-route-id")
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+	if !resp.State.Raw.IsNull() {
+		t.Error("expected the resource to be removed from state on a genuine 404")
+	}
+}
+
+func TestRead_500ProducesErrorAndLeavesStateIntact(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"boom"}`))
+	})
+
+	resp := readRoute(t, client, "route-id")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a 500 response")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a server error must not remove the resource from state")
+	}
+}
+
+func TestRead_RateLimitedProducesErrorAndLeavesStateIntact(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"message":"Too Many Requests"}`))
+	})
+
+	resp := readRoute(t, client, "route-id")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a 429 response")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a rate-limited error must not remove the resource from state")
+	}
+}
+
+func TestRead_TransportErrorProducesErrorAndLeavesStateIntact(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	mg := mailgun.NewMailgun("test-key")
+	if err := mg.SetAPIBase(srv.URL); err != nil {
+		t.Fatalf("SetAPIBase: %v", err)
+	}
+	srv.Close() // connections to this address now fail outright
+
+	resp := readRoute(t, mg, "route-id")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a transport failure")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a transport failure must not remove the resource from state")
+	}
+}

--- a/internal/provider/smtp_credentials/resource.go
+++ b/internal/provider/smtp_credentials/resource.go
@@ -15,6 +15,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mailgun/mailgun-go/v5"
 	"github.com/mailgun/mailgun-go/v5/mtypes"
+
+	"github.com/hackthebox/terraform-provider-mailgun/internal/provider/mgerr"
 )
 
 // errCredentialNotFound drives findEventually's retry loop during Create: a
@@ -198,7 +200,7 @@ func (r *SmtpCredentialResource) Read(ctx context.Context, req resource.ReadRequ
 	login := state.Login.ValueString()
 
 	// Find the credential in the API
-	credential, found, err := r.findCredential(ctx, domain, login)
+	credential, found, err := r.findCredentialForRead(ctx, domain, login)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading SMTP Credential",
@@ -454,6 +456,21 @@ func (r *SmtpCredentialResource) lookupCreatedCredential(ctx context.Context, do
 		return nil, errCredentialNotFound
 	}
 	return cred, nil
+}
+
+// findCredentialForRead adapts findCredential for Read: a genuine 404 means
+// the parent domain was deleted out of band, which collapses to the same
+// "not found" outcome as an empty listing so Read only has one not-found
+// branch to handle instead of two.
+func (r *SmtpCredentialResource) findCredentialForRead(ctx context.Context, domain, login string) (*mtypes.Credential, bool, error) {
+	cred, found, err := r.findCredential(ctx, domain, login)
+	if err != nil {
+		if mgerr.IsNotFound(err) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return cred, found, nil
 }
 
 // findCredential searches for a specific credential by domain and login. The

--- a/internal/provider/smtp_credentials/resource.go
+++ b/internal/provider/smtp_credentials/resource.go
@@ -5,6 +5,7 @@ package smtp_credentials
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -15,6 +16,11 @@ import (
 	"github.com/mailgun/mailgun-go/v5"
 	"github.com/mailgun/mailgun-go/v5/mtypes"
 )
+
+// errCredentialNotFound drives findEventually's retry loop during Create: a
+// scan miss right after creation is Mailgun's listing lagging the write, not
+// a real absence, so it is retried exactly like any other lookup error.
+var errCredentialNotFound = errors.New("credential not found")
 
 const (
 	createdAtLookupAttempts = 4
@@ -157,7 +163,14 @@ func (r *SmtpCredentialResource) Create(ctx context.Context, req resource.Create
 	defer cancelLookup()
 
 	credential, err := findEventually(lookupCtx, createdAtLookupAttempts, createdAtLookupDelay, func() (*mtypes.Credential, error) {
-		return r.findCredential(lookupCtx, domain, login)
+		cred, found, ferr := r.findCredential(lookupCtx, domain, login)
+		if ferr != nil {
+			return nil, ferr
+		}
+		if !found {
+			return nil, errCredentialNotFound
+		}
+		return cred, nil
 	})
 	if err != nil {
 		// Null, not a client-side stamp the server would contradict; Read fills it in.
@@ -192,9 +205,15 @@ func (r *SmtpCredentialResource) Read(ctx context.Context, req resource.ReadRequ
 	login := state.Login.ValueString()
 
 	// Find the credential in the API
-	credential, err := r.findCredential(ctx, domain, login)
+	credential, found, err := r.findCredential(ctx, domain, login)
 	if err != nil {
-		// Credential not found - remove from state
+		resp.Diagnostics.AddError(
+			"Error Reading SMTP Credential",
+			fmt.Sprintf("Could not read SMTP credential %s@%s: %s", login, domain, err),
+		)
+		return
+	}
+	if !found {
 		resp.State.RemoveResource(ctx)
 		return
 	}
@@ -338,11 +357,18 @@ func (r *SmtpCredentialResource) ImportState(ctx context.Context, req resource.I
 	}
 
 	// Find the credential in the API
-	credential, err := r.findCredential(ctx, domain, login)
+	credential, found, err := r.findCredential(ctx, domain, login)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Importing SMTP Credential",
 			fmt.Sprintf("Could not find SMTP credential %s@%s: %s", login, domain, err),
+		)
+		return
+	}
+	if !found {
+		resp.Diagnostics.AddError(
+			"SMTP Credential Not Found",
+			fmt.Sprintf("No SMTP credential %s@%s exists to import.", login, domain),
 		)
 		return
 	}
@@ -420,8 +446,11 @@ func resolveUpdatePassword(passwordWO, planPW types.String, planVersion, stateVe
 	}
 }
 
-// findCredential searches for a specific credential by domain and login
-func (r *SmtpCredentialResource) findCredential(ctx context.Context, domain, login string) (*mtypes.Credential, error) {
+// findCredential searches for a specific credential by domain and login. The
+// bool return distinguishes "not present" from a listing failure, so Read
+// can tell a genuine miss from a transport/API error instead of treating
+// both as deleted (see domain_sending_keys.findKey for the same shape).
+func (r *SmtpCredentialResource) findCredential(ctx context.Context, domain, login string) (*mtypes.Credential, bool, error) {
 	// Create context with timeout
 	findCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
@@ -435,14 +464,14 @@ func (r *SmtpCredentialResource) findCredential(ctx context.Context, domain, log
 			// The API returns full login (login@domain), so we need to compare appropriately
 			expectedFullLogin := fmt.Sprintf("%s@%s", login, domain)
 			if cred.Login == expectedFullLogin || cred.Login == login {
-				return &cred, nil
+				return &cred, true, nil
 			}
 		}
 	}
 
 	if err := iterator.Err(); err != nil {
-		return nil, fmt.Errorf("error listing credentials: %w", err)
+		return nil, false, fmt.Errorf("error listing credentials: %w", err)
 	}
 
-	return nil, fmt.Errorf("credential not found")
+	return nil, false, nil
 }

--- a/internal/provider/smtp_credentials/resource.go
+++ b/internal/provider/smtp_credentials/resource.go
@@ -163,14 +163,7 @@ func (r *SmtpCredentialResource) Create(ctx context.Context, req resource.Create
 	defer cancelLookup()
 
 	credential, err := findEventually(lookupCtx, createdAtLookupAttempts, createdAtLookupDelay, func() (*mtypes.Credential, error) {
-		cred, found, ferr := r.findCredential(lookupCtx, domain, login)
-		if ferr != nil {
-			return nil, ferr
-		}
-		if !found {
-			return nil, errCredentialNotFound
-		}
-		return cred, nil
+		return r.lookupCreatedCredential(lookupCtx, domain, login)
 	})
 	if err != nil {
 		// Null, not a client-side stamp the server would contradict; Read fills it in.
@@ -444,6 +437,23 @@ func resolveUpdatePassword(passwordWO, planPW types.String, planVersion, stateVe
 	default:
 		return planPW.ValueString(), true, ""
 	}
+}
+
+// lookupCreatedCredential adapts findCredential's (found, err) result into
+// the single-error shape findEventually retries on. A genuine listing
+// failure and "not yet visible" are both worth retrying during Create, but
+// they stay distinguishable in the returned error: a listing failure
+// surfaces as-is (so mailgun.GetStatusFromErr still resolves it), while
+// "not yet visible" surfaces as errCredentialNotFound.
+func (r *SmtpCredentialResource) lookupCreatedCredential(ctx context.Context, domain, login string) (*mtypes.Credential, error) {
+	cred, found, err := r.findCredential(ctx, domain, login)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, errCredentialNotFound
+	}
+	return cred, nil
 }
 
 // findCredential searches for a specific credential by domain and login. The

--- a/internal/provider/smtp_credentials/resource_create_import_internal_test.go
+++ b/internal/provider/smtp_credentials/resource_create_import_internal_test.go
@@ -1,0 +1,273 @@
+// Copyright Hack The Box 2025, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package smtp_credentials
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/mailgun/mailgun-go/v5"
+)
+
+func createCredential(t *testing.T, client *mailgun.Client, planOverrides, configOverrides map[string]tftypes.Value) *resource.CreateResponse {
+	t.Helper()
+
+	resourceSchema := SmtpCredentialResourceSchema()
+	plan := credentialObject(t, planOverrides)
+	config := credentialObject(t, configOverrides)
+
+	resp := &resource.CreateResponse{State: tfsdk.State{Raw: plan, Schema: resourceSchema}}
+	(&SmtpCredentialResource{client: client}).Create(context.Background(), resource.CreateRequest{
+		Plan:   tfsdk.Plan{Raw: plan, Schema: resourceSchema},
+		Config: tfsdk.Config{Raw: config, Schema: resourceSchema},
+	}, resp)
+	return resp
+}
+
+func createdCredentialListResponse() []byte {
+	return []byte(`{"total_count":1,"items":[{"login":"user@example.com","created_at":"Mon, 02 Jan 2006 15:04:05 UTC"}]}`)
+}
+
+func TestCreate_Success_LegacyPassword(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodPost:
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(createdCredentialListResponse())
+		}
+	})
+
+	resp := createCredential(t, client,
+		map[string]tftypes.Value{
+			"domain":   tftypes.NewValue(tftypes.String, "example.com"),
+			"login":    tftypes.NewValue(tftypes.String, "user"),
+			"password": tftypes.NewValue(tftypes.String, "legacy-secret"),
+		},
+		map[string]tftypes.Value{
+			"domain":   tftypes.NewValue(tftypes.String, "example.com"),
+			"login":    tftypes.NewValue(tftypes.String, "user"),
+			"password": tftypes.NewValue(tftypes.String, "legacy-secret"),
+		},
+	)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+}
+
+func TestCreate_Success_WriteOnlyPassword(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodPost:
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(createdCredentialListResponse())
+		}
+	})
+
+	resp := createCredential(t, client,
+		map[string]tftypes.Value{
+			"domain": tftypes.NewValue(tftypes.String, "example.com"),
+			"login":  tftypes.NewValue(tftypes.String, "user"),
+		},
+		map[string]tftypes.Value{
+			"domain":              tftypes.NewValue(tftypes.String, "example.com"),
+			"login":               tftypes.NewValue(tftypes.String, "user"),
+			"password_wo":         tftypes.NewValue(tftypes.String, "wo-secret"),
+			"password_wo_version": tftypes.NewValue(tftypes.Number, int64(1)),
+		},
+	)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+}
+
+func TestCreate_MissingDomain(t *testing.T) {
+	resp := createCredential(t, testClient(t, func(http.ResponseWriter, *http.Request) {}),
+		map[string]tftypes.Value{
+			"login":    tftypes.NewValue(tftypes.String, "user"),
+			"password": tftypes.NewValue(tftypes.String, "secret"),
+		},
+		map[string]tftypes.Value{
+			"login":    tftypes.NewValue(tftypes.String, "user"),
+			"password": tftypes.NewValue(tftypes.String, "secret"),
+		},
+	)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a missing domain")
+	}
+}
+
+func TestCreate_MissingLogin(t *testing.T) {
+	resp := createCredential(t, testClient(t, func(http.ResponseWriter, *http.Request) {}),
+		map[string]tftypes.Value{
+			"domain":   tftypes.NewValue(tftypes.String, "example.com"),
+			"password": tftypes.NewValue(tftypes.String, "secret"),
+		},
+		map[string]tftypes.Value{
+			"domain":   tftypes.NewValue(tftypes.String, "example.com"),
+			"password": tftypes.NewValue(tftypes.String, "secret"),
+		},
+	)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a missing login")
+	}
+}
+
+func TestCreate_MissingPassword(t *testing.T) {
+	resp := createCredential(t, testClient(t, func(http.ResponseWriter, *http.Request) {}),
+		map[string]tftypes.Value{
+			"domain": tftypes.NewValue(tftypes.String, "example.com"),
+			"login":  tftypes.NewValue(tftypes.String, "user"),
+		},
+		map[string]tftypes.Value{
+			"domain": tftypes.NewValue(tftypes.String, "example.com"),
+			"login":  tftypes.NewValue(tftypes.String, "user"),
+		},
+	)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic when neither password source is set")
+	}
+}
+
+func TestCreate_UnconfiguredClient(t *testing.T) {
+	overrides := map[string]tftypes.Value{
+		"domain":   tftypes.NewValue(tftypes.String, "example.com"),
+		"login":    tftypes.NewValue(tftypes.String, "user"),
+		"password": tftypes.NewValue(tftypes.String, "secret"),
+	}
+
+	resp := createCredential(t, nil, overrides, overrides)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic when the client is not configured")
+	}
+}
+
+func TestCreate_CreateCredentialAPIError(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"boom"}`))
+	})
+
+	overrides := map[string]tftypes.Value{
+		"domain":   tftypes.NewValue(tftypes.String, "example.com"),
+		"login":    tftypes.NewValue(tftypes.String, "user"),
+		"password": tftypes.NewValue(tftypes.String, "secret"),
+	}
+
+	resp := createCredential(t, client, overrides, overrides)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic when CreateCredential fails")
+	}
+}
+
+// The created_at lookup is best-effort: if the listing never catches up
+// within the retry budget, Create must still succeed with created_at left
+// null for Read to fill in later, not fail the apply.
+func TestCreate_LookupNeverCatchesUp_LeavesCreatedAtNull(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodPost:
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"total_count":0,"items":[]}`))
+		}
+	})
+
+	overrides := map[string]tftypes.Value{
+		"domain":   tftypes.NewValue(tftypes.String, "example.com"),
+		"login":    tftypes.NewValue(tftypes.String, "user"),
+		"password": tftypes.NewValue(tftypes.String, "secret"),
+	}
+
+	resp := createCredential(t, client, overrides, overrides)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+}
+
+func importCredential(t *testing.T, client *mailgun.Client, id string) *resource.ImportStateResponse {
+	t.Helper()
+
+	resp := &resource.ImportStateResponse{
+		State: tfsdk.State{Schema: SmtpCredentialResourceSchema()},
+	}
+	(&SmtpCredentialResource{client: client}).ImportState(context.Background(), resource.ImportStateRequest{ID: id}, resp)
+	return resp
+}
+
+func TestImportState_InvalidID(t *testing.T) {
+	resp := importCredential(t, testClient(t, func(http.ResponseWriter, *http.Request) {}), "not-a-valid-id")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a malformed import ID")
+	}
+}
+
+func TestImportState_UnconfiguredClient(t *testing.T) {
+	resp := importCredential(t, nil, "example.com/user")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic when the client is not configured")
+	}
+}
+
+func TestImportState_ListFailureProducesError(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"boom"}`))
+	})
+
+	resp := importCredential(t, client, "example.com/user")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic when the credential listing fails")
+	}
+}
+
+func TestImportState_CredentialNotFound(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"total_count":0,"items":[]}`))
+	})
+
+	resp := importCredential(t, client, "example.com/gone-user")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic when the credential does not exist")
+	}
+}
+
+func TestImportState_Success(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(createdCredentialListResponse())
+	})
+
+	resp := importCredential(t, client, "example.com/user")
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+}

--- a/internal/provider/smtp_credentials/resource_create_import_internal_test.go
+++ b/internal/provider/smtp_credentials/resource_create_import_internal_test.go
@@ -5,6 +5,7 @@ package smtp_credentials
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"testing"
 
@@ -13,6 +14,63 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/mailgun/mailgun-go/v5"
 )
+
+// lookupCreatedCredential must surface a genuine listing failure as its own
+// error, not collapse it into the "not found yet" sentinel findEventually
+// also retries on: the two must stay distinguishable so a caller inspecting
+// the error (e.g. via mailgun.GetStatusFromErr) sees the real cause.
+func TestLookupCreatedCredential_ReturnsUnderlyingErrorOnListingFailure(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"boom"}`))
+	})
+
+	r := &SmtpCredentialResource{client: client}
+	_, err := r.lookupCreatedCredential(context.Background(), "example.com", "user")
+
+	if err == nil {
+		t.Fatal("expected an error when the listing itself fails")
+	}
+	if errors.Is(err, errCredentialNotFound) {
+		t.Error("a listing failure must not be reported as the not-found sentinel")
+	}
+	if got := mailgun.GetStatusFromErr(err); got != http.StatusInternalServerError {
+		t.Errorf("GetStatusFromErr(err) = %d, want %d (the underlying error must survive)", got, http.StatusInternalServerError)
+	}
+}
+
+func TestLookupCreatedCredential_ReturnsSentinelWhenNotYetVisible(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"total_count":0,"items":[]}`))
+	})
+
+	r := &SmtpCredentialResource{client: client}
+	_, err := r.lookupCreatedCredential(context.Background(), "example.com", "user")
+
+	if !errors.Is(err, errCredentialNotFound) {
+		t.Errorf("err = %v, want errCredentialNotFound", err)
+	}
+}
+
+func TestLookupCreatedCredential_ReturnsCredentialWhenFound(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(createdCredentialListResponse())
+	})
+
+	r := &SmtpCredentialResource{client: client}
+	cred, err := r.lookupCreatedCredential(context.Background(), "example.com", "user")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cred.Login != "user@example.com" {
+		t.Errorf("cred.Login = %q, want %q", cred.Login, "user@example.com")
+	}
+}
 
 func createCredential(t *testing.T, client *mailgun.Client, planOverrides, configOverrides map[string]tftypes.Value) *resource.CreateResponse {
 	t.Helper()

--- a/internal/provider/smtp_credentials/resource_read_internal_test.go
+++ b/internal/provider/smtp_credentials/resource_read_internal_test.go
@@ -1,0 +1,153 @@
+// Copyright Hack The Box 2025, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package smtp_credentials
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/mailgun/mailgun-go/v5"
+)
+
+func testClient(t *testing.T, handler http.HandlerFunc) *mailgun.Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	mg := mailgun.NewMailgun("test-key")
+	if err := mg.SetAPIBase(srv.URL); err != nil {
+		t.Fatalf("SetAPIBase: %v", err)
+	}
+	return mg
+}
+
+func TestFindCredential_ReturnsFoundTrueWhenPresent(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"total_count":1,"items":[{"login":"user@example.com"}]}`))
+	})
+
+	r := &SmtpCredentialResource{client: client}
+	cred, found, err := r.findCredential(context.Background(), "example.com", "user")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected the credential to be found")
+	}
+	if cred.Login != "user@example.com" {
+		t.Errorf("cred.Login = %q, want %q", cred.Login, "user@example.com")
+	}
+}
+
+func TestFindCredential_ReturnsFoundFalseWhenAbsent(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"total_count":0,"items":[]}`))
+	})
+
+	r := &SmtpCredentialResource{client: client}
+	_, found, err := r.findCredential(context.Background(), "example.com", "gone-user")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found {
+		t.Error("expected the credential not to be found")
+	}
+}
+
+func TestFindCredential_ReturnsErrorOnListFailure(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"boom"}`))
+	})
+
+	r := &SmtpCredentialResource{client: client}
+	_, found, err := r.findCredential(context.Background(), "example.com", "user")
+
+	if err == nil {
+		t.Fatal("expected an error when the listing itself fails")
+	}
+	if found {
+		t.Error("found must be false when err is non-nil")
+	}
+}
+
+func readCredential(t *testing.T, client *mailgun.Client, domain, login string) *resource.ReadResponse {
+	t.Helper()
+
+	resourceSchema := SmtpCredentialResourceSchema()
+	raw := credentialObject(t, map[string]tftypes.Value{
+		"domain": tftypes.NewValue(tftypes.String, domain),
+		"login":  tftypes.NewValue(tftypes.String, login),
+	})
+	state := tfsdk.State{Raw: raw, Schema: resourceSchema}
+
+	resp := &resource.ReadResponse{State: state}
+	(&SmtpCredentialResource{client: client}).Read(context.Background(), resource.ReadRequest{State: state}, resp)
+	return resp
+}
+
+func TestRead_RemovesResourceWhenCredentialAbsent(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"total_count":0,"items":[]}`))
+	})
+
+	resp := readCredential(t, client, "example.com", "gone-user")
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+	if !resp.State.Raw.IsNull() {
+		t.Error("expected the resource to be removed from state when the credential is absent")
+	}
+}
+
+// A listing failure (500, rate limit, transport error) is not the same as
+// the credential being gone: it must produce a diagnostic and leave state
+// intact rather than silently dropping a live resource.
+func TestRead_ListFailureProducesErrorAndLeavesStateIntact(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"boom"}`))
+	})
+
+	resp := readCredential(t, client, "example.com", "user")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic when the credential listing fails")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a listing failure must not remove the resource from state")
+	}
+}
+
+func TestRead_TransportErrorProducesErrorAndLeavesStateIntact(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	mg := mailgun.NewMailgun("test-key")
+	if err := mg.SetAPIBase(srv.URL); err != nil {
+		t.Fatalf("SetAPIBase: %v", err)
+	}
+	srv.Close() // connections to this address now fail outright
+
+	resp := readCredential(t, mg, "example.com", "user")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a transport failure")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a transport failure must not remove the resource from state")
+	}
+}

--- a/internal/provider/smtp_credentials/resource_read_internal_test.go
+++ b/internal/provider/smtp_credentials/resource_read_internal_test.go
@@ -103,6 +103,50 @@ func readCredential(t *testing.T, client *mailgun.Client, domain, login string) 
 	return resp
 }
 
+// A genuine 404 from the domain-scoped credentials listing means the parent
+// domain was deleted out of band, not that the listing merely failed; Read
+// must recover the same way it does for an empty listing.
+func TestRead_RemovesResourceOnGenuine404(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Domain not found"}`))
+	})
+
+	resp := readCredential(t, client, "gone.example.com", "user")
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+	if !resp.State.Raw.IsNull() {
+		t.Error("expected the resource to be removed from state on a genuine 404")
+	}
+}
+
+func TestRead_UpdatesStateWhenCredentialFound(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"total_count":1,"items":[{"login":"user@example.com","created_at":"Mon, 02 Jan 2006 15:04:05 -0700"}]}`))
+	})
+
+	resp := readCredential(t, client, "example.com", "user")
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+
+	var state SmtpCredentialModel
+	if diags := resp.State.Get(context.Background(), &state); diags.HasError() {
+		t.Fatalf("unexpected diagnostics reading back state: %v", diags)
+	}
+	if state.FullLogin.ValueString() != "user@example.com" {
+		t.Errorf("state.FullLogin = %q, want %q", state.FullLogin.ValueString(), "user@example.com")
+	}
+	if state.Id.ValueString() != "example.com/user" {
+		t.Errorf("state.Id = %q, want %q", state.Id.ValueString(), "example.com/user")
+	}
+}
+
 func TestRead_RemovesResourceWhenCredentialAbsent(t *testing.T) {
 	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/provider/smtp_credentials/resource_read_internal_test.go
+++ b/internal/provider/smtp_credentials/resource_read_internal_test.go
@@ -81,6 +81,11 @@ func TestFindCredential_ReturnsErrorOnListFailure(t *testing.T) {
 	if found {
 		t.Error("found must be false when err is non-nil")
 	}
+	// The wire status must survive the wrap (%w, not %v), or callers using
+	// errors.As/Is (and mgerr.IsNotFound, transitively) lose the cause.
+	if got := mailgun.GetStatusFromErr(err); got != http.StatusInternalServerError {
+		t.Errorf("GetStatusFromErr(err) = %d, want %d (the wire status must survive the wrap)", got, http.StatusInternalServerError)
+	}
 }
 
 func readCredential(t *testing.T, client *mailgun.Client, domain, login string) *resource.ReadResponse {

--- a/internal/provider/template_versions/resource.go
+++ b/internal/provider/template_versions/resource.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hackthebox/terraform-provider-mailgun/internal/provider/mgerr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mailgun/mailgun-go/v5"
@@ -153,8 +154,7 @@ func (r *templateVersionResource) Read(ctx context.Context, req resource.ReadReq
 
 	version, err := r.client.GetTemplateVersion(readCtx, domain, templateName, tag)
 	if err != nil {
-		// Check if version doesn't exist
-		if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "404") {
+		if mgerr.IsNotFound(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/provider/template_versions/resource_read_internal_test.go
+++ b/internal/provider/template_versions/resource_read_internal_test.go
@@ -1,0 +1,152 @@
+// Copyright Hack The Box 2025, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package template_versions
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/mailgun/mailgun-go/v5"
+)
+
+func testClient(t *testing.T, handler http.HandlerFunc) *mailgun.Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	mg := mailgun.NewMailgun("test-key")
+	if err := mg.SetAPIBase(srv.URL); err != nil {
+		t.Fatalf("SetAPIBase: %v", err)
+	}
+	return mg
+}
+
+// templateVersionStateObject builds a resource-shaped tftypes.Value,
+// defaulting every attribute to null and applying the given overrides.
+func templateVersionStateObject(t *testing.T, overrides map[string]tftypes.Value) tftypes.Value {
+	t.Helper()
+
+	objType, ok := TemplateVersionResourceSchema().Type().TerraformType(context.Background()).(tftypes.Object)
+	if !ok {
+		t.Fatal("schema terraform type is not an object")
+	}
+
+	attrs := make(map[string]tftypes.Value, len(objType.AttributeTypes))
+	for name, attrType := range objType.AttributeTypes {
+		if override, found := overrides[name]; found {
+			attrs[name] = override
+			continue
+		}
+		attrs[name] = tftypes.NewValue(attrType, nil)
+	}
+
+	return tftypes.NewValue(objType, attrs)
+}
+
+func readTemplateVersion(t *testing.T, client *mailgun.Client, tag string) *resource.ReadResponse {
+	t.Helper()
+
+	resourceSchema := TemplateVersionResourceSchema()
+	state := tfsdk.State{
+		Raw: templateVersionStateObject(t, map[string]tftypes.Value{
+			"domain":        tftypes.NewValue(tftypes.String, "example.com"),
+			"template_name": tftypes.NewValue(tftypes.String, "my-template"),
+			"tag":           tftypes.NewValue(tftypes.String, tag),
+		}),
+		Schema: resourceSchema,
+	}
+
+	resp := &resource.ReadResponse{State: state}
+	(&templateVersionResource{client: client}).Read(context.Background(), resource.ReadRequest{State: state}, resp)
+	return resp
+}
+
+func TestRead_RemovesResourceOnGenuine404(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Template version not found"}`))
+	})
+
+	resp := readTemplateVersion(t, client, "gone-tag")
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+	if !resp.State.Raw.IsNull() {
+		t.Error("expected the resource to be removed from state on a genuine 404")
+	}
+}
+
+// A 500 whose body happens to mention "not found" must not be mistaken for a
+// 404: the string-matching this replaces would remove a live resource here.
+func TestRead_500MentioningNotFoundIsNotTreatedAsMissing(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"upstream dependency not found: 404 from internal service"}`))
+	})
+
+	resp := readTemplateVersion(t, client, "v1")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a 500 response, even one mentioning 'not found'")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a 500 must not remove the resource from state just because its body mentions 'not found'")
+	}
+}
+
+func TestRead_500ProducesErrorAndLeavesStateIntact(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"boom"}`))
+	})
+
+	resp := readTemplateVersion(t, client, "v1")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a 500 response")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a server error must not remove the resource from state")
+	}
+}
+
+func TestRead_RateLimitedProducesErrorAndLeavesStateIntact(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"message":"Too Many Requests"}`))
+	})
+
+	resp := readTemplateVersion(t, client, "v1")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a 429 response")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a rate-limited error must not remove the resource from state")
+	}
+}
+
+func TestRead_TransportErrorProducesErrorAndLeavesStateIntact(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	mg := mailgun.NewMailgun("test-key")
+	if err := mg.SetAPIBase(srv.URL); err != nil {
+		t.Fatalf("SetAPIBase: %v", err)
+	}
+	srv.Close() // connections to this address now fail outright
+
+	resp := readTemplateVersion(t, mg, "v1")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a transport failure")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a transport failure must not remove the resource from state")
+	}
+}

--- a/internal/provider/templates/resource.go
+++ b/internal/provider/templates/resource.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hackthebox/terraform-provider-mailgun/internal/provider/mgerr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mailgun/mailgun-go/v5"
@@ -146,8 +147,7 @@ func (r *templateResource) Read(ctx context.Context, req resource.ReadRequest, r
 
 	template, err := r.client.GetTemplate(readCtx, domain, name)
 	if err != nil {
-		// Check if template doesn't exist
-		if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "404") {
+		if mgerr.IsNotFound(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/provider/templates/resource_read_internal_test.go
+++ b/internal/provider/templates/resource_read_internal_test.go
@@ -1,0 +1,151 @@
+// Copyright Hack The Box 2025, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package templates
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/mailgun/mailgun-go/v5"
+)
+
+func testClient(t *testing.T, handler http.HandlerFunc) *mailgun.Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	mg := mailgun.NewMailgun("test-key")
+	if err := mg.SetAPIBase(srv.URL); err != nil {
+		t.Fatalf("SetAPIBase: %v", err)
+	}
+	return mg
+}
+
+// templateStateObject builds a resource-shaped tftypes.Value, defaulting
+// every attribute to null and applying the given overrides.
+func templateStateObject(t *testing.T, overrides map[string]tftypes.Value) tftypes.Value {
+	t.Helper()
+
+	objType, ok := TemplateResourceSchema().Type().TerraformType(context.Background()).(tftypes.Object)
+	if !ok {
+		t.Fatal("schema terraform type is not an object")
+	}
+
+	attrs := make(map[string]tftypes.Value, len(objType.AttributeTypes))
+	for name, attrType := range objType.AttributeTypes {
+		if override, found := overrides[name]; found {
+			attrs[name] = override
+			continue
+		}
+		attrs[name] = tftypes.NewValue(attrType, nil)
+	}
+
+	return tftypes.NewValue(objType, attrs)
+}
+
+func readTemplate(t *testing.T, client *mailgun.Client, name string) *resource.ReadResponse {
+	t.Helper()
+
+	resourceSchema := TemplateResourceSchema()
+	state := tfsdk.State{
+		Raw: templateStateObject(t, map[string]tftypes.Value{
+			"domain": tftypes.NewValue(tftypes.String, "example.com"),
+			"name":   tftypes.NewValue(tftypes.String, name),
+		}),
+		Schema: resourceSchema,
+	}
+
+	resp := &resource.ReadResponse{State: state}
+	(&templateResource{client: client}).Read(context.Background(), resource.ReadRequest{State: state}, resp)
+	return resp
+}
+
+func TestRead_RemovesResourceOnGenuine404(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Template not found"}`))
+	})
+
+	resp := readTemplate(t, client, "gone-template")
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+	if !resp.State.Raw.IsNull() {
+		t.Error("expected the resource to be removed from state on a genuine 404")
+	}
+}
+
+// A 500 whose body happens to mention "not found" must not be mistaken for a
+// 404: the string-matching this replaces would remove a live resource here.
+func TestRead_500MentioningNotFoundIsNotTreatedAsMissing(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"upstream dependency not found: 404 from internal service"}`))
+	})
+
+	resp := readTemplate(t, client, "my-template")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a 500 response, even one mentioning 'not found'")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a 500 must not remove the resource from state just because its body mentions 'not found'")
+	}
+}
+
+func TestRead_500ProducesErrorAndLeavesStateIntact(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"boom"}`))
+	})
+
+	resp := readTemplate(t, client, "my-template")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a 500 response")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a server error must not remove the resource from state")
+	}
+}
+
+func TestRead_RateLimitedProducesErrorAndLeavesStateIntact(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"message":"Too Many Requests"}`))
+	})
+
+	resp := readTemplate(t, client, "my-template")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a 429 response")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a rate-limited error must not remove the resource from state")
+	}
+}
+
+func TestRead_TransportErrorProducesErrorAndLeavesStateIntact(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	mg := mailgun.NewMailgun("test-key")
+	if err := mg.SetAPIBase(srv.URL); err != nil {
+		t.Fatalf("SetAPIBase: %v", err)
+	}
+	srv.Close() // connections to this address now fail outright
+
+	resp := readTemplate(t, mg, "my-template")
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a transport failure")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a transport failure must not remove the resource from state")
+	}
+}

--- a/internal/provider/webhooks/resource.go
+++ b/internal/provider/webhooks/resource.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hackthebox/terraform-provider-mailgun/internal/provider/mgerr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mailgun/mailgun-go/v5"
@@ -110,8 +111,12 @@ func (r *webhookResource) Read(ctx context.Context, req resource.ReadRequest, re
 
 	urls, err := r.client.GetWebhook(readCtx, domain, webhookType)
 	if err != nil {
-		// Check if webhook doesn't exist
-		if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "404") {
+		// GetWebhook signals absence two ways: a typed 404 when the domain
+		// itself is gone, and a bare "returned no urls" sentinel (200 OK, empty
+		// webhook object) when the domain exists but this webhook doesn't. The
+		// webhook's entire content is its URL list, so "no URLs" and "absent"
+		// are the same state from Terraform's point of view.
+		if mgerr.IsNotFound(err) || strings.Contains(err.Error(), "returned no urls") {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/provider/webhooks/resource_read_internal_test.go
+++ b/internal/provider/webhooks/resource_read_internal_test.go
@@ -1,0 +1,171 @@
+// Copyright Hack The Box 2025, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package webhooks
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/mailgun/mailgun-go/v5"
+)
+
+func testClient(t *testing.T, handler http.HandlerFunc) *mailgun.Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	mg := mailgun.NewMailgun("test-key")
+	if err := mg.SetAPIBase(srv.URL); err != nil {
+		t.Fatalf("SetAPIBase: %v", err)
+	}
+	return mg
+}
+
+// webhookStateObject builds a resource-shaped tftypes.Value, defaulting
+// every attribute to null and applying the given overrides.
+func webhookStateObject(t *testing.T, overrides map[string]tftypes.Value) tftypes.Value {
+	t.Helper()
+
+	objType, ok := WebhookResourceSchema().Type().TerraformType(context.Background()).(tftypes.Object)
+	if !ok {
+		t.Fatal("schema terraform type is not an object")
+	}
+
+	attrs := make(map[string]tftypes.Value, len(objType.AttributeTypes))
+	for name, attrType := range objType.AttributeTypes {
+		if override, found := overrides[name]; found {
+			attrs[name] = override
+			continue
+		}
+		attrs[name] = tftypes.NewValue(attrType, nil)
+	}
+
+	return tftypes.NewValue(objType, attrs)
+}
+
+func readWebhook(t *testing.T, client *mailgun.Client) *resource.ReadResponse {
+	t.Helper()
+
+	resourceSchema := WebhookResourceSchema()
+	state := tfsdk.State{
+		Raw: webhookStateObject(t, map[string]tftypes.Value{
+			"domain":       tftypes.NewValue(tftypes.String, "example.com"),
+			"webhook_type": tftypes.NewValue(tftypes.String, "opened"),
+		}),
+		Schema: resourceSchema,
+	}
+
+	resp := &resource.ReadResponse{State: state}
+	(&webhookResource{client: client}).Read(context.Background(), resource.ReadRequest{State: state}, resp)
+	return resp
+}
+
+func TestRead_RemovesResourceOnGenuine404(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Webhook not found"}`))
+	})
+
+	resp := readWebhook(t, client)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+	if !resp.State.Raw.IsNull() {
+		t.Error("expected the resource to be removed from state on a genuine 404")
+	}
+}
+
+// The SDK reports an empty webhook object (200 OK, no url/urls) as the bare
+// error `webhook '%s' returned no urls`, not as a typed 404. See
+// mailgun-go/v5@v5.19.1/webhooks.go GetWebhook.
+func TestRead_RemovesResourceWhenSDKReportsNoURLsSentinel(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"webhook":{}}`))
+	})
+
+	resp := readWebhook(t, client)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+	if !resp.State.Raw.IsNull() {
+		t.Error("expected the resource to be removed from state when the SDK reports no urls")
+	}
+}
+
+// A 500 whose body happens to mention "not found" must not be mistaken for a
+// 404: the string-matching this replaces would remove a live resource here.
+func TestRead_500MentioningNotFoundIsNotTreatedAsMissing(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"upstream dependency not found: 404 from internal service"}`))
+	})
+
+	resp := readWebhook(t, client)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a 500 response, even one mentioning 'not found'")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a 500 must not remove the resource from state just because its body mentions 'not found'")
+	}
+}
+
+func TestRead_500ProducesErrorAndLeavesStateIntact(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"boom"}`))
+	})
+
+	resp := readWebhook(t, client)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a 500 response")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a server error must not remove the resource from state")
+	}
+}
+
+func TestRead_RateLimitedProducesErrorAndLeavesStateIntact(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"message":"Too Many Requests"}`))
+	})
+
+	resp := readWebhook(t, client)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a 429 response")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a rate-limited error must not remove the resource from state")
+	}
+}
+
+func TestRead_TransportErrorProducesErrorAndLeavesStateIntact(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	mg := mailgun.NewMailgun("test-key")
+	if err := mg.SetAPIBase(srv.URL); err != nil {
+		t.Fatalf("SetAPIBase: %v", err)
+	}
+	srv.Close() // connections to this address now fail outright
+
+	resp := readWebhook(t, mg)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected a diagnostic for a transport failure")
+	}
+	if resp.State.Raw.IsNull() {
+		t.Error("a transport failure must not remove the resource from state")
+	}
+}


### PR DESCRIPTION
Phase A of #102. Fixes the 404-handling defects a practitioner actually hits. Does not close the issue: the client convergence work is Phase B.

Refs #102.

## The two defects

**1. An out-of-band delete permanently wedged `plan` for three resources.** `mailgun_domain`, `mailgun_route` and `mailgun_domain_tracking` returned a hard error when Read got a 404, instead of calling `resp.State.RemoveResource(ctx)`. Deleting a domain or route in the Mailgun UI left `plan`, `apply` and `destroy` all failing until the user hand-ran `terraform state rm`. Read now removes the resource from state on a genuine 404, so the next plan recreates it.

**2. Transport errors were being reported as "resource deleted", silently dropping live resources from state.** Two separate causes:

- `strings.Contains(err.Error(), "404")` / `"not found"`. `UnexpectedResponseError.String()` formats the request URL and the raw response body into the message, so that predicate was true for *any* error on a resource whose name contains `404`, and for any 500 whose body says "not found".
- `domain_sending_keys`, `smtp_credentials`, `domain_ip` and `domain_dkim_key` Read did `if err != nil { RemoveResource() }`, so a 500, a 401 or a network blip during `terraform plan` removed a live resource from state and planned a recreate. No unusual naming needed.

Both now use `mgerr.IsNotFound`, a single typed check over the SDK's `GetStatusFromErr`, and the listing-based lookups return `(value, found bool, err error)` so a genuine miss is distinguishable from a failure. That shape already existed in `domain_dkim_key` and `domain_ip`; this makes it consistent.

## Notes for reviewers

**`webhooks` does not use the typed check alone.** `GetWebhook` signals absence as `fmt.Errorf("webhook '%s' returned no urls", name)` on an HTTP **200** (mailgun-go/v5 `webhooks.go:65-81`), and `webhook_type` is constrained by `stringvalidator.OneOf`, so a genuine 404 is unreachable there. It keeps one narrow sentinel check for that specific message, pinned by a test that fails loudly if the SDK rewords it. The generic `404`/`not found` matching is gone.

**`domain_ip` and `domain_dkim_key` were added beyond the original scope** because they carry the same `if err != nil { RemoveResource() }` defect. Kept deliberately rather than deferred.

**`ip_allowlist` is untouched.** Its hand-rolled client returns plain `fmt.Errorf` strings that carry no status, so converging it requires client changes. That is Phase B.

## Testing

Nine new internal test files on the credential-free `httptest` + `SetAPIBase` seam that already existed at `domains/resource_retry_internal_test.go`. No API key, no network, runs in `make test`.

The important cases are the false-positive locks: a 500 whose body contains the text `not found` must produce an error and **not** a state removal, and a listing failure must propagate rather than masquerade as absence. Those are the behaviours this PR changes, and they are what a careless future refactor would reintroduce.

Coverage on touched packages: `smtp_credentials` 12.5% → 42.8%, `domain_sending_keys` 1.3% → 16.1%, `webhooks` 1.3% → 10.8%, `templates` 1.0% → 8.3%, new `mgerr` at 100%.

Resource-level Read branches remain covered only by acceptance tests, which need `TF_ACC=1` and `MAILGUN_API_KEY` against a live paid account. Those were not run.

## Gates

```
go build ./...      ok
go vet ./...        ok
golangci-lint run   0 issues
make test           0 failures
make generate       no diff
```

CRAP gate green, all 11 changed source files `measured` (no `--mark-scored` override).

Mutation gate green, with one recorded user-accepted equivalent mutant: `resp.State.RemoveResource(ctx)` → `RemoveResource(nil)` at `domain_dkim_key/resource.go:143`. `tfsdk.State.RemoveResource` threads `ctx` only into `Type().TerraformType(ctx)`, which ignores it for every framework type, so no test can distinguish the two. A second survivor in `mgerr` was a genuinely unreachable nil guard and was deleted rather than accepted.
